### PR TITLE
#3 feature: 여러 페이지에서 필요한 헤더바 & 사이드바를 구현합니다.

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,28 @@
+import { Menu } from "lucide-react";
+
+interface HeaderProps {
+	onToggleSidebar: () => void;
+}
+
+export default function Header({ onToggleSidebar }: HeaderProps) {
+	return (
+		<header className="h-12 bg-white flex items-center px-4 justify-between">
+			{/* 왼쪽 섹션 */}
+			<section className="flex items-center gap-2">
+				<button
+					onClick={onToggleSidebar}
+					className="p-1.5 hover:bg-gray-100 rounded transition-colors"
+					aria-label="메뉴 열기">
+					<Menu className="w-5 h-5 text-gray-600" />
+				</button>
+			</section>
+
+			{/* 오른쪽 섹션 */}
+			<section className="flex items-center gap-4">
+				<button className="px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-100 rounded transition-colors">
+					로그인
+				</button>
+			</section>
+		</header>
+	);
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,0 +1,129 @@
+import { motion, AnimatePresence } from "framer-motion";
+import { Search, Plus, Inbox, MoreHorizontal } from "lucide-react";
+import { personalCarts, sharedCarts } from "../../mock/cartData.ts";
+import { useModalStore } from "../../store/useModalStore";
+
+interface SidebarProps {
+	isOpen: boolean;
+}
+
+export default function Sidebar({ isOpen }: SidebarProps) {
+	// 모달 store에서 액션 가져오기
+	const openSearchModal = useModalStore((state) => state.openSearchModal);
+	const openCreateCartModal = useModalStore(
+		(state) => state.openCreateCartModal
+	);
+	const openCreateSharedCartModal = useModalStore(
+		(state) => state.openCreateSharedCartModal
+	);
+
+	return (
+		<>
+			{/* 사이드바 본체 */}
+			<AnimatePresence>
+				{isOpen && (
+					<motion.aside
+						initial={{ x: -280 }}
+						animate={{ x: 0 }}
+						exit={{ x: -280 }}
+						transition={{ type: "spring", damping: 25, stiffness: 200 }}
+						className="fixed top-20 bottom-8 left-3 w-64 bg-[#fbfbfa] border border-gray-200 rounded-2xl z-50 flex flex-col shadow-lg overflow-hidden">
+						{/* 유저 섹션 */}
+						<section className="p-3 border-b border-gray-200">
+							<button className="w-full flex items-center gap-2 p-1.5 hover:bg-gray-200/50 rounded transition-colors">
+								{/* 유저 아바타 */}
+								<div className="w-6 h-6 bg-linear-to-br from-orange-400 to-pink-400 rounded flex items-center justify-center text-white text-xs font-semibold">
+									K
+								</div>
+								<span className="text-sm font-medium text-gray-800">
+									장바구니 사용자
+								</span>
+							</button>
+						</section>
+
+						{/* 메인 네비게이션 */}
+						<section className="flex-1 overflow-y-auto py-2">
+							{/* 검색 버튼 */}
+							<button
+								onClick={openSearchModal}
+								className="w-full px-3 py-1.5 flex items-center gap-2 text-sm text-gray-600 hover:bg-gray-200/50 transition-colors">
+								<Search className="w-4 h-4" />
+								<span>검색</span>
+							</button>
+
+							{/* 개인 장바구니 섹션 */}
+							<section className="mb-4 mt-4">
+								{/* 섹션 헤더 */}
+								<div className="w-full px-3 py-1">
+									<span className="text-xs text-gray-500 font-medium">
+										개인 장바구니
+									</span>
+								</div>
+
+								{/* 개인 장바구니 목록 */}
+								<div className="mt-1">
+									{personalCarts.map((cart) => (
+										<button
+											key={cart.id}
+											className="w-full px-3 pl-6 py-1.5 flex items-center gap-2 text-sm text-gray-700 hover:bg-gray-200/50 transition-colors group/item">
+											<Inbox className="w-4 h-4" />
+											<span className="flex-1 text-left">{cart.name}</span>
+											<div className="opacity-0 group-hover/item:opacity-100 transition-opacity">
+												<button className="p-0.5 hover:bg-gray-300/50 rounded">
+													<MoreHorizontal className="w-3.5 h-3.5 text-gray-500" />
+												</button>
+											</div>
+										</button>
+									))}
+
+									{/* 새 장바구니 추가 버튼 */}
+									<button
+										onClick={openCreateCartModal}
+										className="w-full px-3 pl-6 py-1.5 flex items-center gap-2 text-sm text-gray-500 hover:bg-gray-200/50 transition-colors">
+										<Plus className="w-4 h-4" />
+										<span>새 장바구니 추가</span>
+									</button>
+								</div>
+							</section>
+
+							{/* 공유 장바구니 섹션 */}
+							<section>
+								{/* 섹션 헤더 */}
+								<div className="w-full px-3 py-1">
+									<span className="text-xs text-gray-500 font-medium">
+										공유 장바구니
+									</span>
+								</div>
+
+								{/* 공유 장바구니 목록 */}
+								<div className="mt-1">
+									{sharedCarts.map((cart) => (
+										<button
+											key={cart.id}
+											className="w-full px-3 pl-6 py-1.5 flex items-center gap-2 text-sm text-gray-700 hover:bg-gray-200/50 transition-colors group/item">
+											<Inbox className="w-4 h-4" />
+											<span className="flex-1 text-left">{cart.name}</span>
+											<div className="opacity-0 group-hover/item:opacity-100 transition-opacity">
+												<button className="p-0.5 hover:bg-gray-300/50 rounded">
+													<MoreHorizontal className="w-3.5 h-3.5 text-gray-500" />
+												</button>
+											</div>
+										</button>
+									))}
+
+									{/* 새 공유 장바구니 추가 버튼 */}
+									<button
+										onClick={openCreateSharedCartModal}
+										className="w-full px-3 pl-6 py-1.5 flex items-center gap-2 text-sm text-gray-500 hover:bg-gray-200/50 transition-colors">
+										<Plus className="w-4 h-4" />
+										<span>새 공유 장바구니 추가</span>
+									</button>
+								</div>
+							</section>
+						</section>
+					</motion.aside>
+				)}
+			</AnimatePresence>
+		</>
+	);
+}

--- a/src/components/modals/CreateCartModal.tsx
+++ b/src/components/modals/CreateCartModal.tsx
@@ -1,0 +1,227 @@
+import { motion } from "framer-motion";
+import { X, Plus, Trash2 } from "lucide-react";
+import { useState, useEffect } from "react";
+import { useModalStore } from "../../store/useModalStore";
+
+// 공유 장바구니 여부
+interface CreateCartModalProps {
+	isShared: boolean;
+}
+
+export default function CreateCartModal({ isShared }: CreateCartModalProps) {
+	// 폼 상태
+	const [isPublic, setIsPublic] = useState(false);
+	const [cartName, setCartName] = useState("");
+	const [budget, setBudget] = useState("");
+	const [emails, setEmails] = useState<string[]>([""]);
+
+	// 모달 닫기 액션 가져오기
+	const closeCreateCartModal = useModalStore(
+		(state) => state.closeCreateCartModal
+	);
+	const closeCreateSharedCartModal = useModalStore(
+		(state) => state.closeCreateSharedCartModal
+	);
+
+	// isShared 값에 따라 적절한 닫기 함수 선택
+	const handleClose = isShared
+		? closeCreateSharedCartModal
+		: closeCreateCartModal;
+
+	// ESC 키로 모달 닫기
+	useEffect(() => {
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (e.key === "Escape") {
+				handleClose();
+			}
+		};
+		window.addEventListener("keydown", handleKeyDown);
+		return () => window.removeEventListener("keydown", handleKeyDown);
+	}, [handleClose]);
+
+	// 이메일 입력 핸들러
+	const handleAddEmail = () => {
+		setEmails([...emails, ""]);
+	};
+
+	// 추가한 이메일 삭제 버튼 핸들러
+	const handleRemoveEmail = (index: number) => {
+		setEmails(emails.filter((_, i) => i !== index));
+	};
+
+	/**
+	 * 이메일 값 변경
+	 */
+	const handleEmailChange = (index: number, value: string) => {
+		const newEmails = [...emails];
+		newEmails[index] = value;
+		setEmails(newEmails);
+	};
+
+	// 추후 API 연동하여 폼 제출 시 데이터 제공
+	const handleSubmit = () => {
+		console.log({
+			isShared,
+			isPublic,
+			cartName,
+			budget,
+			emails: emails.filter((email) => email.trim() !== ""),
+		});
+		handleClose();
+	};
+
+	return (
+		<div className="fixed inset-0 z-50 flex items-center justify-center">
+			{/* 배경 오버레이 */}
+			<motion.div
+				initial={{ opacity: 0 }}
+				animate={{ opacity: 1 }}
+				exit={{ opacity: 0 }}
+				className="absolute inset-0 bg-black/40"
+				onClick={handleClose}
+			/>
+
+			{/* 모달 본체 */}
+			<motion.div
+				initial={{ opacity: 0, scale: 0.95, y: 20 }}
+				animate={{ opacity: 1, scale: 1, y: 0 }}
+				exit={{ opacity: 0, scale: 0.95, y: 20 }}
+				transition={{ type: "spring", damping: 25, stiffness: 300 }}
+				className="relative bg-white rounded-lg shadow-xl w-full max-w-md mx-4 overflow-hidden"
+				onClick={(e) => e.stopPropagation()}>
+				{/* 헤더 */}
+				<div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+					<h2 className="text-lg font-semibold text-gray-900">
+						{isShared ? "새 공유 장바구니 만들기" : "새 장바구니 만들기"}
+					</h2>
+					<button
+						onClick={handleClose}
+						className="p-1 hover:bg-gray-100 rounded transition-colors">
+						<X className="w-5 h-5 text-gray-500" />
+					</button>
+				</div>
+
+				{/* 폼 컨텐츠 */}
+				<div className="px-6 py-4 space-y-4 max-h-[70vh] overflow-y-auto">
+					{/* 공개/비공개 토글 */}
+					<div>
+						<label className="block text-sm font-medium text-gray-700 mb-2">
+							공개/비공개 선택 <span className="text-red-500">*</span>
+						</label>
+						<div className="flex gap-2">
+							<button
+								onClick={() => setIsPublic(false)}
+								className={`flex-1 px-4 py-2 rounded-lg border-2 transition-all ${
+									!isPublic
+										? "border-blue-500 bg-blue-50 text-blue-700"
+										: "border-gray-200 bg-white text-gray-600 hover:bg-gray-50"
+								}`}>
+								비공개
+							</button>
+							<button
+								onClick={() => setIsPublic(true)}
+								className={`flex-1 px-4 py-2 rounded-lg border-2 transition-all ${
+									isPublic
+										? "border-blue-500 bg-blue-50 text-blue-700"
+										: "border-gray-200 bg-white text-gray-600 hover:bg-gray-50"
+								}`}>
+								공개
+							</button>
+						</div>
+					</div>
+
+					{/* 장바구니 이름 */}
+					<div>
+						<label
+							htmlFor="cart-name"
+							className="block text-sm font-medium text-gray-700 mb-2">
+							장바구니 이름 <span className="text-red-500">*</span>
+						</label>
+						<input
+							id="cart-name"
+							type="text"
+							value={cartName}
+							onChange={(e) => setCartName(e.target.value)}
+							placeholder="예: 생활용품 구매 목록"
+							className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+						/>
+					</div>
+
+					{/* 예산 */}
+					<div>
+						<label
+							htmlFor="budget"
+							className="block text-sm font-medium text-gray-700 mb-2">
+							예산 (선택사항)
+						</label>
+						<div className="relative">
+							<input
+								id="budget"
+								type="text"
+								value={budget}
+								onChange={(e) => setBudget(e.target.value)}
+								placeholder="0"
+								className="w-full px-3 py-2 pr-8 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+							/>
+							<span className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 text-sm">
+								원
+							</span>
+						</div>
+					</div>
+
+					{/* 공유 장바구니일 경우에만 초대 멤버 표시 */}
+					{isShared && (
+						<div>
+							<label className="block text-sm font-medium text-gray-700 mb-2">
+								초대할 사람 (선택사항)
+							</label>
+							<div className="space-y-2">
+								{emails.map((email, index) => (
+									<div key={index} className="flex gap-2">
+										<input
+											type="email"
+											value={email}
+											onChange={(e) => handleEmailChange(index, e.target.value)}
+											placeholder="example@email.com"
+											className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+										/>
+										{emails.length > 1 && (
+											<button
+												onClick={() => handleRemoveEmail(index)}
+												className="p-2 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded transition-colors">
+												<Trash2 className="w-4 h-4" />
+											</button>
+										)}
+									</div>
+								))}
+
+								{/* 이메일 추가 버튼 */}
+								<button
+									onClick={handleAddEmail}
+									className="flex items-center gap-1 text-sm text-blue-600 hover:text-blue-700 font-medium">
+									<Plus className="w-4 h-4" />
+									이메일 추가
+								</button>
+							</div>
+						</div>
+					)}
+				</div>
+
+				{/* 푸터 - 액션 버튼 */}
+				<div className="px-6 py-4 border-t border-gray-200 flex justify-end gap-2">
+					<button
+						onClick={handleClose}
+						className="px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 rounded-lg transition-colors">
+						취소
+					</button>
+					<button
+						onClick={handleSubmit}
+						disabled={!cartName.trim()}
+						className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed rounded-lg transition-colors">
+						생성하기
+					</button>
+				</div>
+			</motion.div>
+		</div>
+	);
+}

--- a/src/components/modals/SearchModal.tsx
+++ b/src/components/modals/SearchModal.tsx
@@ -1,0 +1,76 @@
+import { motion } from "framer-motion";
+import { Search, X } from "lucide-react";
+import { useState, useEffect } from "react";
+import { useModalStore } from "../../store/useModalStore";
+
+export default function SearchModal() {
+	// 검색어 상태
+	const [searchQuery, setSearchQuery] = useState("");
+
+	// store에서 모달 닫기 액션 가져오기
+	const closeSearchModal = useModalStore((state) => state.closeSearchModal);
+
+	// ESC 키로 모달 닫기
+	useEffect(() => {
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (e.key === "Escape") {
+				closeSearchModal();
+			}
+		};
+		window.addEventListener("keydown", handleKeyDown);
+		return () => window.removeEventListener("keydown", handleKeyDown);
+	}, [closeSearchModal]);
+
+	return (
+		<div className="fixed inset-0 z-50 flex items-start justify-center pt-20">
+			{/* 배경 오버레이 */}
+			<motion.div
+				initial={{ opacity: 0 }}
+				animate={{ opacity: 1 }}
+				exit={{ opacity: 0 }}
+				className="absolute inset-0 bg-black/40"
+				onClick={closeSearchModal}
+			/>
+
+			{/* 모달 본체 */}
+			<motion.div
+				initial={{ opacity: 0, scale: 0.95, y: -20 }}
+				animate={{ opacity: 1, scale: 1, y: 0 }}
+				exit={{ opacity: 0, scale: 0.95, y: -20 }}
+				transition={{ type: "spring", damping: 25, stiffness: 300 }}
+				className="relative bg-white rounded-lg shadow-xl w-full max-w-2xl mx-4 overflow-hidden"
+				onClick={(e) => e.stopPropagation()}>
+				{/* 검색 입력 영역 */}
+				<div className="flex items-center gap-3 px-4 py-3 border-b border-gray-200">
+					<Search className="w-5 h-5 text-gray-400" />
+					<input
+						type="text"
+						value={searchQuery}
+						onChange={(e) => setSearchQuery(e.target.value)}
+						placeholder="검색..."
+						autoFocus
+						className="flex-1 text-base outline-none"
+					/>
+					<button
+						onClick={closeSearchModal}
+						className="p-1 hover:bg-gray-100 rounded transition-colors">
+						<X className="w-5 h-5 text-gray-500" />
+					</button>
+				</div>
+
+				{/* 검색 결과 영역 */}
+				<div className="px-4 py-6 min-h-50">
+					{searchQuery ? (
+						<p className="text-sm text-gray-500 text-center">
+							"{searchQuery}"에 대한 검색 결과가 없습니다.
+						</p>
+					) : (
+						<p className="text-sm text-gray-400 text-center">
+							검색어를 입력하세요
+						</p>
+					)}
+				</div>
+			</motion.div>
+		</div>
+	);
+}

--- a/src/mock/cartData.ts
+++ b/src/mock/cartData.ts
@@ -1,0 +1,17 @@
+interface PersonalCart {
+	id: number;
+	name: string;
+}
+
+interface SharedCart {
+	id: number;
+	name: string;
+}
+
+export const personalCarts: PersonalCart[] = [
+	{ id: 1, name: "겨울 옷 쇼핑 목록" },
+];
+
+export const sharedCarts: SharedCart[] = [
+	{ id: 1, name: "Wisoft 겨울 워크숍" },
+];

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,3 +1,128 @@
+import { useState } from "react";
+import Header from "../components/layout/Header.tsx";
+import Sidebar from "../components/layout/Sidebar.tsx";
+import SearchModal from "../components/modals/SearchModal";
+import CreateCartModal from "../components/modals/CreateCartModal";
+import { useModalStore } from "../store/useModalStore";
+
 export default function MainPage() {
-	return <div>MainPage</div>;
+	// 사이드바 열림/닫힘 상태
+	const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+
+	// store에서 모달 상태 가져옴
+	const isSearchModalOpen = useModalStore((state) => state.isSearchModalOpen);
+	const isCreateCartModalOpen = useModalStore(
+		(state) => state.isCreateCartModalOpen
+	);
+	const isCreateSharedCartModalOpen = useModalStore(
+		(state) => state.isCreateSharedCartModalOpen
+	);
+
+	return (
+		<div className="h-screen flex flex-col overflow-hidden bg-white">
+			{/* 헤더 */}
+			<Header onToggleSidebar={() => setIsSidebarOpen(!isSidebarOpen)} />
+
+			<div className="flex flex-1 overflow-hidden">
+				{/* 사이드바 */}
+				<Sidebar isOpen={isSidebarOpen} />
+
+				{/* 메인 콘텐츠 영역 */}
+				<main className="flex-1 overflow-auto">
+					<div className="max-w-4xl mx-auto px-6 py-16">
+						<div className="space-y-8">
+							{/* 환영 메시지 */}
+							<div>
+								<h1 className="text-4xl font-bold text-gray-900 mb-4">
+									공유 장바구니 서비스에 오신 것을 환영합니다
+								</h1>
+								<p className="text-xl text-gray-600">
+									함께 쇼핑하고, 함께 관리하세요
+								</p>
+							</div>
+
+							<div className="space-y-6">
+								{/* 서비스 소개 섹션 */}
+								<section>
+									<h2 className="text-2xl font-semibold text-gray-900 mb-3">
+										우리의 서비스
+									</h2>
+									<p className="text-gray-700 leading-relaxed">
+										공유 장바구니는 개인과 팀이 함께 상품을 관리하고 구매할 수
+										있는 협업 쇼핑 플랫폼입니다. 가족, 친구, 동료들과 함께
+										장바구니를 공유하고 예산을 관리하며, 효율적으로 쇼핑할 수
+										있습니다.
+									</p>
+								</section>
+
+								{/* 주요 기능 섹션 */}
+								<section>
+									<h2 className="text-2xl font-semibold text-gray-900 mb-3">
+										주요 기능
+									</h2>
+									<ul className="space-y-3 text-gray-700">
+										{/* 개인 장바구니 기능 */}
+										<li className="flex items-start gap-2">
+											<span className="text-blue-500 mt-1">•</span>
+											<span>
+												<strong>개인 장바구니:</strong> 개인적인 쇼핑 목록을
+												체계적으로 관리하세요
+											</span>
+										</li>
+
+										{/* 공유 장바구니 기능 */}
+										<li className="flex items-start gap-2">
+											<span className="text-blue-500 mt-1">•</span>
+											<span>
+												<strong>공유 장바구니:</strong> 팀원들과 실시간으로
+												장바구니를 공유하고 협업하세요
+											</span>
+										</li>
+
+										{/* 예산 관리 기능 */}
+										<li className="flex items-start gap-2">
+											<span className="text-blue-500 mt-1">•</span>
+											<span>
+												<strong>예산 관리:</strong> 각 장바구니별로 예산을
+												설정하고 지출을 추적하세요
+											</span>
+										</li>
+
+										{/* 초대 시스템 기능 */}
+										<li className="flex items-start gap-2">
+											<span className="text-blue-500 mt-1">•</span>
+											<span>
+												<strong>초대 시스템:</strong> 이메일로 간편하게 멤버를
+												초대하고 권한을 관리하세요
+											</span>
+										</li>
+									</ul>
+								</section>
+
+								{/* 시작하기 섹션 */}
+								<section>
+									<h2 className="text-2xl font-semibold text-gray-900 mb-3">
+										시작하기
+									</h2>
+									<p className="text-gray-700 leading-relaxed">
+										왼쪽 상단의 메뉴 버튼을 클릭하여 사이드바를 열고, 새로운
+										장바구니를 만들어보세요. 개인 장바구니 또는 공유 장바구니를
+										선택할 수 있으며, 필요에 따라 예산과 협업 멤버를 설정할 수
+										있습니다.
+									</p>
+								</section>
+							</div>
+						</div>
+					</div>
+				</main>
+			</div>
+
+			{/* 모달 컴포넌트들은 store의 상태에 따라 조건부 렌더링 */}
+			{isSearchModalOpen && <SearchModal />}
+
+			{isCreateCartModalOpen && <CreateCartModal isShared={false} />}
+
+			{isCreateSharedCartModalOpen && <CreateCartModal isShared={true} />}
+		</div>
+	);
 }

--- a/src/store/useModalStore.ts
+++ b/src/store/useModalStore.ts
@@ -1,0 +1,37 @@
+import { create } from "zustand";
+import { combine } from "zustand/middleware";
+
+// 모달 상태 관리 스토어
+export const useModalStore = create(
+	combine(
+		{
+			// 초기 상태
+			isSearchModalOpen: false,
+			isCreateCartModalOpen: false,
+			isCreateSharedCartModalOpen: false,
+		},
+		(set) => ({
+			// 검색 모달 액션
+			openSearchModal: () => set({ isSearchModalOpen: true }),
+			closeSearchModal: () => set({ isSearchModalOpen: false }),
+
+			// 장바구니 생성 모달 액션
+			openCreateCartModal: () => set({ isCreateCartModalOpen: true }),
+			closeCreateCartModal: () => set({ isCreateCartModalOpen: false }),
+
+			// 공유 장바구니 생성 모달 액션
+			openCreateSharedCartModal: () =>
+				set({ isCreateSharedCartModalOpen: true }),
+			closeCreateSharedCartModal: () =>
+				set({ isCreateSharedCartModalOpen: false }),
+
+			// 모든 모달 닫기
+			closeAllModals: () =>
+				set({
+					isSearchModalOpen: false,
+					isCreateCartModalOpen: false,
+					isCreateSharedCartModalOpen: false,
+				}),
+		})
+	)
+);


### PR DESCRIPTION
## 🛠️ 설명 (Description)

- 임시로 사용 할 헤더바와 메인 페이지 구현하였습니다.
- 검색과 장바구니 관리 할 수 있는 사이드바 구현하였습니다.
  - 전역에서 사용되는 사이드바를 위해 사이드바의 `state`를 `store`에 별도로 관리합니다.
  - `store`에 `combine` 미들웨어를 사용하여 자동 타입 추론이 가능케 하였습니다.
- 사이드바에서 사용될 모달들을 구현하였습니다.
  - 개인/공유 장바구니 모달들은 조건부 렌더링을 통해 공유 장바구니에서만 이메일 입력이 가능하게 구현하였습니다.

## 📄 설계 문서 (Design Document)

## 📝 변경 사항 요약 (Summary)

- `src/components/layout`: 사이드바와 임시로 사용할 헤더바 구현
- `src/components/modals`: 개인/공유 장바구니와 검색 모달 구현
- `src/pages/MainPage.tsx`: 임시로 사용될 메인 페이지 구현

## 🔗 관련 이슈 (Related Issues)

- Closes #None
- Related #3 

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

<img width="1470" height="784" alt="image" src="https://github.com/user-attachments/assets/bb2f4bc8-265a-412d-ae7d-769a7b3fee26" />


## ➕ 추가 정보 (Additional Information)
