### PR TITLE
#17 feature: 장바구니 페이지 UI 구현 및 모달 렌더링 구조 분리

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
 
 <body>
   <div id="root"></div>
+  <div id="modal-root"></div>
   <script type="module" src="/src/main.tsx"></script>
 </body>
 

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -3,7 +3,7 @@ import { Facebook, Instagram, ShoppingCart } from "lucide-react";
 export default function Footer() {
 	return (
 		<footer className="w-full bg-white border-t border-[#EAEAEA] mt-16">
-			<div className="max-w-5xl mx-auto px-6 py-16 space-y-12">
+			<div className="max-w-7xl mx-auto px-6 py-16 space-y-12">
 				<div className="flex flex-col gap-10 md:flex-row md:items-center md:justify-between">
 					<div className="space-y-3">
 						<div className="flex items-center gap-2">

--- a/src/components/layout/GlobalLayout.tsx
+++ b/src/components/layout/GlobalLayout.tsx
@@ -1,27 +1,10 @@
 import { Outlet } from "react-router-dom";
 import SubHeader from "./SubHeader";
 import Sidebar from "./Sidebar.tsx";
-
-import CreateCartModal from "../modals/CreateCartModal";
-import SelectCartModal from "../modals/SelectCartModal";
-import AddToCartModal from "../modals/AddToCartModal";
-import {
-	useIsCreateCartModalOpen,
-	useIsCreateSharedCartModalOpen,
-	useIsAddToCartModalOpen,
-	useIsSelectCartModalOpen,
-} from "../../store/useCartModalStore.ts";
 import MainHeader from "./MainHeader";
 import Footer from "./Footer.tsx";
 
 export default function GlobalLayout() {
-	// store에서 모달 상태 가져옴
-
-	const isCreateCartModalOpen = useIsCreateCartModalOpen();
-	const isCreateSharedCartModalOpen = useIsCreateSharedCartModalOpen();
-	const isAddToCartModalOpen = useIsAddToCartModalOpen();
-	const isSelectCartModalOpen = useIsSelectCartModalOpen();
-
 	return (
 		<div className="min-h-screen flex flex-col bg-white">
 			{/* 헤더 - 상단 네비게이션 */}
@@ -38,12 +21,6 @@ export default function GlobalLayout() {
 				</main>
 			</div>
 
-			{/* 모달 컴포넌트들은 store의 상태에 따라 조건부 렌더링 */}
-			{(isCreateCartModalOpen || isCreateSharedCartModalOpen) && (
-				<CreateCartModal />
-			)}
-			{isAddToCartModalOpen && <AddToCartModal />}
-			{isSelectCartModalOpen && <SelectCartModal />}
 			<Footer />
 		</div>
 	);

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { motion, AnimatePresence } from "framer-motion";
 import { Plus, Inbox, MoreHorizontal, X } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 import { personalCarts, sharedCarts } from "../../mock/cartData.ts";
 import {
 	useIsSidebarOpen,
@@ -9,116 +10,134 @@ import {
 } from "../../store/useCartModalStore.ts";
 
 export default function Sidebar() {
-	// store에서 상태 및 액션 가져오기
 	const isSidebarOpen = useIsSidebarOpen();
 	const closeSidebar = useCloseSidebar();
 	const openCreateCartModal = useOpenCreateCartModal();
 	const openCreateSharedCartModal = useOpenCreateSharedCartModal();
+	const navigate = useNavigate();
+
+	const handleCartClick = (cartId: number, cartType: "personal" | "shared") => {
+		closeSidebar();
+		navigate(`/cart?id=${cartId}&type=${cartType}`);
+	};
 
 	return (
 		<>
-			{/* 사이드바 본체 */}
 			<AnimatePresence>
 				{isSidebarOpen && (
-					<motion.aside
-						initial={{ x: 400 }}
-						animate={{ x: 0 }}
-						exit={{ x: 400 }}
-						transition={{ type: "spring", damping: 25, stiffness: 200 }}
-						className="fixed top-14 bottom-8 right-2 w-80 bg-[#FDFBF6] border border-[#EDE9E0] rounded-2xl z-50 flex flex-col shadow-lg overflow-hidden">
-						{/* 유저 섹션 */}
-						<section className="p-3 border-b border-gray-200">
-							<div className="flex items-center justify-between">
-								<button className="flex items-center gap-2 p-1.5 hover:bg-gray-200/50 rounded transition-colors">
-									{/* 유저 아바타 */}
-									<div className="w-6 h-6 bg-linear-to-br from-orange-400 to-pink-400 rounded flex items-center justify-center text-white text-xs font-semibold">
-										K
+					<>
+						{/* 배경 오버레이 - 클릭 시 사이드바 닫기 */}
+						<motion.div
+							key="sidebar-overlay"
+							initial={{ opacity: 0 }}
+							animate={{ opacity: 1 }}
+							exit={{ opacity: 0 }}
+							transition={{ duration: 0.2 }}
+							className="fixed inset-0 z-40 bg-black/20"
+							onClick={closeSidebar}
+						/>
+
+						{/* 사이드바 본체 */}
+						<motion.aside
+							key="sidebar-panel"
+							initial={{ x: 400 }}
+							animate={{ x: 0 }}
+							exit={{ x: 400 }}
+							transition={{ type: "spring", damping: 25, stiffness: 200 }}
+							className="fixed top-14 bottom-8 right-2 w-80 bg-[#FDFBF6] border border-[#EDE9E0] rounded-2xl z-50 flex flex-col shadow-lg overflow-hidden">
+							{/* 유저 섹션 */}
+							<section className="p-3 border-b border-gray-200">
+								<div className="flex items-center justify-between">
+									<button className="flex items-center gap-2 p-1.5 hover:bg-gray-200/50 rounded transition-colors">
+										<div className="w-6 h-6 bg-linear-to-br from-orange-400 to-pink-400 rounded flex items-center justify-center text-white text-xs font-semibold">
+											K
+										</div>
+										<span className="text-m font-medium text-gray-800">
+											장바구니 사용자
+										</span>
+									</button>
+									<button
+										onClick={closeSidebar}
+										className="p-1 hover:bg-gray-200/50 rounded transition-colors">
+										<X className="w-4 h-4 text-gray-500" />
+									</button>
+								</div>
+							</section>
+
+							{/* 메인 네비게이션 */}
+							<section className="flex-1 overflow-y-auto py-2">
+								{/* 개인 장바구니 섹션 */}
+								<section className="mb-4 mt-4">
+									<div className="w-full px-3 py-1">
+										<span className="text-sm text-gray-500 font-medium">
+											개인 장바구니
+										</span>
 									</div>
-									<span className="text-m font-medium text-gray-800">
-										장바구니 사용자
-									</span>
-								</button>
-								<button
-									onClick={closeSidebar}
-									className="p-1 hover:bg-gray-200/50 rounded transition-colors">
-									<X className="w-4 h-4 text-gray-500" />
-								</button>
-							</div>
-						</section>
 
-						{/* 메인 네비게이션 */}
-						<section className="flex-1 overflow-y-auto py-2">
-							{/* 개인 장바구니 섹션 */}
-							<section className="mb-4 mt-4">
-								{/* 섹션 헤더 */}
-								<div className="w-full px-3 py-1">
-									<span className="text-sm text-gray-500 font-medium">
-										개인 장바구니
-									</span>
-								</div>
+									<div className="mt-1">
+										{personalCarts.map((cart) => (
+											<button
+												key={cart.id}
+												onClick={() => handleCartClick(cart.id, "personal")}
+												className="w-full px-3 pl-6 py-1.5 flex items-center gap-2 text-base text-gray-700 hover:bg-gray-200/50 transition-colors group/item">
+												<Inbox className="w-4 h-4" />
+												<span className="flex-1 text-left">{cart.name}</span>
+												<div className="opacity-0 group-hover/item:opacity-100 transition-opacity">
+													<button
+														onClick={(e) => e.stopPropagation()}
+														className="p-0.5 hover:bg-gray-300/50 rounded">
+														<MoreHorizontal className="w-3.5 h-3.5 text-gray-500" />
+													</button>
+												</div>
+											</button>
+										))}
 
-								{/* 개인 장바구니 목록 */}
-								<div className="mt-1">
-									{personalCarts.map((cart) => (
 										<button
-											key={cart.id}
-											className="w-full px-3 pl-6 py-1.5 flex items-center gap-2 text-base text-gray-700 hover:bg-gray-200/50 transition-colors group/item">
-											<Inbox className="w-4 h-4" />
-											<span className="flex-1 text-left">{cart.name}</span>
-											<div className="opacity-0 group-hover/item:opacity-100 transition-opacity">
-												<button className="p-0.5 hover:bg-gray-300/50 rounded">
-													<MoreHorizontal className="w-3.5 h-3.5 text-gray-500" />
-												</button>
-											</div>
+											onClick={openCreateCartModal}
+											className="w-full px-3 pl-6 py-1.5 flex items-center gap-2 text-base text-gray-500 hover:bg-gray-200/50 transition-colors">
+											<Plus className="w-4 h-4" />
+											<span>새 장바구니 추가</span>
 										</button>
-									))}
+									</div>
+								</section>
 
-									{/* 새 장바구니 추가 버튼 */}
-									<button
-										onClick={openCreateCartModal}
-										className="w-full px-3 pl-6 py-1.5 flex items-center gap-2 text-base text-gray-500 hover:bg-gray-200/50 transition-colors">
-										<Plus className="w-4 h-4" />
-										<span>새 장바구니 추가</span>
-									</button>
-								</div>
-							</section>
+								{/* 공유 장바구니 섹션 */}
+								<section>
+									<div className="w-full px-3 py-1">
+										<span className="text-sm text-gray-500 font-medium">
+											공유 장바구니
+										</span>
+									</div>
 
-							{/* 공유 장바구니 섹션 */}
-							<section>
-								{/* 섹션 헤더 */}
-								<div className="w-full px-3 py-1">
-									<span className="text-sm text-gray-500 font-medium">
-										공유 장바구니
-									</span>
-								</div>
+									<div className="mt-1">
+										{sharedCarts.map((cart) => (
+											<button
+												key={cart.id}
+												onClick={() => handleCartClick(cart.id, "shared")}
+												className="w-full px-3 pl-6 py-1.5 flex items-center gap-2 text-base text-gray-700 hover:bg-gray-200/50 transition-colors group/item">
+												<Inbox className="w-4 h-4" />
+												<span className="flex-1 text-left">{cart.name}</span>
+												<div className="opacity-0 group-hover/item:opacity-100 transition-opacity">
+													<button
+														onClick={(e) => e.stopPropagation()}
+														className="p-0.5 hover:bg-gray-300/50 rounded">
+														<MoreHorizontal className="w-3.5 h-3.5 text-gray-500" />
+													</button>
+												</div>
+											</button>
+										))}
 
-								{/* 공유 장바구니 목록 */}
-								<div className="mt-1">
-									{sharedCarts.map((cart) => (
 										<button
-											key={cart.id}
-											className="w-full px-3 pl-6 py-1.5 flex items-center gap-2 text-base text-gray-700 hover:bg-gray-200/50 transition-colors group/item">
-											<Inbox className="w-4 h-4" />
-											<span className="flex-1 text-left">{cart.name}</span>
-											<div className="opacity-0 group-hover/item:opacity-100 transition-opacity">
-												<button className="p-0.5 hover:bg-gray-300/50 rounded">
-													<MoreHorizontal className="w-3.5 h-3.5 text-gray-500" />
-												</button>
-											</div>
+											onClick={openCreateSharedCartModal}
+											className="w-full px-3 pl-6 py-1.5 flex items-center gap-2 text-base text-gray-500 hover:bg-gray-200/50 transition-colors">
+											<Plus className="w-4 h-4" />
+											<span>새 공유 장바구니 추가</span>
 										</button>
-									))}
-
-									{/* 새 공유 장바구니 추가 버튼 */}
-									<button
-										onClick={openCreateSharedCartModal}
-										className="w-full px-3 pl-6 py-1.5 flex items-center gap-2 text-base text-gray-500 hover:bg-gray-200/50 transition-colors">
-										<Plus className="w-4 h-4" />
-										<span>새 공유 장바구니 추가</span>
-									</button>
-								</div>
+									</div>
+								</section>
 							</section>
-						</section>
-					</motion.aside>
+						</motion.aside>
+					</>
 				)}
 			</AnimatePresence>
 		</>

--- a/src/components/modals/AddToCartModal.tsx
+++ b/src/components/modals/AddToCartModal.tsx
@@ -1,6 +1,6 @@
 import { motion } from "framer-motion";
 import { X } from "lucide-react";
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { useCloseAddToCartModal } from "../../store/useCartModalStore.ts";
 
 // 장바구니 존재 X -> 장바구니 생성 모달
@@ -14,9 +14,9 @@ export default function AddToCartModal() {
 	// 모달 닫기 액션 가져오기
 	const closeAddToCartModal = useCloseAddToCartModal();
 
-	const handleClose = () => {
+	const handleClose = useCallback(() => {
 		closeAddToCartModal();
-	};
+	}, [closeAddToCartModal]);
 
 	const handleSetPrivate = () => {
 		setIsPublic(false);

--- a/src/components/modals/CreateCartModal.tsx
+++ b/src/components/modals/CreateCartModal.tsx
@@ -167,6 +167,23 @@ export default function CreateCartModal() {
 						/>
 					</div>
 
+					{/* 목적 */}
+					<div>
+						<label
+							htmlFor="purpose"
+							className="block text-sm font-medium text-gray-700 mb-2">
+							목적
+						</label>
+						<input
+							id="purpose"
+							type="text"
+							value={purpose}
+							onChange={handlePurposeChange}
+							placeholder="캠핑, 워크샵, 글램핑 등"
+							className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#D9CEBC] focus:border-transparent"
+						/>
+					</div>
+
 					{/* 예산 */}
 					<div>
 						<label
@@ -187,23 +204,6 @@ export default function CreateCartModal() {
 								원
 							</span>
 						</div>
-					</div>
-
-					{/* 목적 */}
-					<div>
-						<label
-							htmlFor="purpose"
-							className="block text-sm font-medium text-gray-700 mb-2">
-							목적 (선택사항)
-						</label>
-						<input
-							id="purpose"
-							type="text"
-							value={purpose}
-							onChange={handlePurposeChange}
-							placeholder="캠핑, 워크샵, 글램핑 등"
-							className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#D9CEBC] focus:border-transparent"
-						/>
 					</div>
 
 					{/* 공유 장바구니일 경우에만 초대 멤버 표시 */}

--- a/src/components/productsDetail/MainSection.tsx
+++ b/src/components/productsDetail/MainSection.tsx
@@ -83,10 +83,11 @@ export default function MainSection() {
 						<button
 							key={index}
 							onClick={() => setSelectedImageIndex(index)}
-							className={`aspect-square rounded-lg overflow-hidden border-2 transition-all ${selectedImageIndex === index
+							className={`aspect-square rounded-lg overflow-hidden border-2 transition-all ${
+								selectedImageIndex === index
 									? "border-[#FFC107]"
 									: "border-gray-200 hover:border-gray-300"
-								}`}>
+							}`}>
 							<img
 								src={image}
 								alt={`상품 이미지 ${index + 1}`}
@@ -113,10 +114,11 @@ export default function MainSection() {
 						{[...Array(5)].map((_, i) => (
 							<Star
 								key={i}
-								className={`w-5 h-5 ${i < Math.floor(product.rating)
+								className={`w-5 h-5 ${
+									i < Math.floor(product.rating)
 										? "fill-yellow-400 text-yellow-400"
 										: "fill-gray-200 text-gray-200"
-									}`}
+								}`}
 							/>
 						))}
 					</div>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,13 +3,16 @@ import "./index.css";
 import App from "./App.jsx";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter } from "react-router-dom";
+import ModalProvider from "./providers/ModalProvider";
 
 const queryClient = new QueryClient();
 
 createRoot(document.getElementById("root")!).render(
 	<BrowserRouter>
 		<QueryClientProvider client={queryClient}>
-			<App />
+			<ModalProvider>
+				<App />
+			</ModalProvider>
 		</QueryClientProvider>
 	</BrowserRouter>
 );

--- a/src/mock/cartData.ts
+++ b/src/mock/cartData.ts
@@ -1,17 +1,86 @@
-interface PersonalCart {
+// 장바구니 상품 아이템 타입
+export interface CartItem {
 	id: number;
+	productId: number;
 	name: string;
+	price: number;
+	quantity: number;
+	thumbnail: string;
 }
 
-interface SharedCart {
+// 개인 장바구니 타입
+export interface PersonalCart {
 	id: number;
 	name: string;
+	items: CartItem[];
+}
+
+// 공유 장바구니 타입
+export interface SharedCart {
+	id: number;
+	name: string;
+	items: CartItem[];
 }
 
 export const personalCarts: PersonalCart[] = [
-	{ id: 1, name: "겨울 옷 쇼핑 목록" },
+	{
+		id: 1,
+		name: "겨울 옷 쇼핑 목록",
+		items: [
+			{
+				id: 1,
+				productId: 101,
+				name: "울 혼방 롱 코트",
+				price: 128000,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1539533018447-63fcce2678e3?w=200&q=80",
+			},
+			{
+				id: 2,
+				productId: 102,
+				name: "캐시미어 터틀넥 니트",
+				price: 56000,
+				quantity: 2,
+				thumbnail:
+					"https://images.unsplash.com/photo-1576566588028-4147f3842f27?w=200&q=80",
+			},
+			{
+				id: 3,
+				productId: 103,
+				name: "퀼팅 패딩 조끼",
+				price: 45000,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1551028719-00167b16eac5?w=200&q=80",
+			},
+		],
+	},
 ];
 
 export const sharedCarts: SharedCart[] = [
-	{ id: 1, name: "Wisoft 겨울 워크숍" },
+	{
+		id: 1,
+		name: "Wisoft 겨울 워크숍",
+		items: [
+			{
+				id: 4,
+				productId: 201,
+				name: "사무용 볼펜 세트 12P",
+				price: 8900,
+				quantity: 5,
+				thumbnail:
+					"https://images.unsplash.com/photo-1532153975070-2e9ab71f1b14?w=200&q=80",
+			},
+			{
+				id: 5,
+				productId: 202,
+				name: "A4 복사용지 500매",
+				price: 12000,
+				quantity: 3,
+				thumbnail:
+					"https://images.unsplash.com/photo-1568667256549-094345857637?w=200&q=80",
+			},
+		],
+	},
 ];

--- a/src/pages/cart/CartDetailPage.tsx
+++ b/src/pages/cart/CartDetailPage.tsx
@@ -1,0 +1,299 @@
+import { useSearchParams, useNavigate } from "react-router-dom";
+import { useState } from "react";
+import { ShoppingBag, Minus, Plus, Trash2 } from "lucide-react";
+import { personalCarts, sharedCarts, type CartItem } from "../../mock/cartData";
+
+export default function CartDetailPage() {
+	const [searchParams] = useSearchParams();
+	const navigate = useNavigate();
+
+	const cartId = Number(searchParams.get("id"));
+	const cartType = searchParams.get("type") as "personal" | "shared" | null;
+
+	// 해당 장바구니 찾기
+	const allCarts = [
+		...personalCarts.map((c) => ({ ...c, type: "personal" as const })),
+		...sharedCarts.map((c) => ({ ...c, type: "shared" as const })),
+	];
+	const cart = allCarts.find((c) => c.id === cartId && c.type === cartType);
+
+	// 로컬 상품 목록 상태 (수량 변경 및 삭제용)
+	const [items, setItems] = useState<CartItem[]>(cart?.items ?? []);
+
+	// 체크박스 선택 상태 (item.id → boolean)
+	const [checkedIds, setCheckedIds] = useState<Set<number>>(
+		new Set(cart?.items.map((i) => i.id) ?? [])
+	);
+
+	/* ── 체크박스 핸들러 ── */
+	const isAllChecked = items.length > 0 && checkedIds.size === items.length;
+	const isIndeterminate = checkedIds.size > 0 && checkedIds.size < items.length;
+
+	const handleToggleAll = () => {
+		if (isAllChecked) {
+			setCheckedIds(new Set());
+		} else {
+			setCheckedIds(new Set(items.map((i) => i.id)));
+		}
+	};
+
+	const handleToggleItem = (id: number) => {
+		setCheckedIds((prev) => {
+			const next = new Set(prev);
+			if (next.has(id)) {
+				next.delete(id);
+			} else {
+				next.add(id);
+			}
+			return next;
+		});
+	};
+
+	/* ── 수량 핸들러 ── */
+	const handleIncrease = (id: number) => {
+		setItems((prev) =>
+			prev.map((item) =>
+				item.id === id ? { ...item, quantity: item.quantity + 1 } : item
+			)
+		);
+	};
+
+	const handleDecrease = (id: number) => {
+		setItems((prev) =>
+			prev.map((item) =>
+				item.id === id && item.quantity > 1
+					? { ...item, quantity: item.quantity - 1 }
+					: item
+			)
+		);
+	};
+
+	/* ── 삭제 핸들러 ── */
+	const handleDelete = (id: number) => {
+		setItems((prev) => prev.filter((item) => item.id !== id));
+		setCheckedIds((prev) => {
+			const next = new Set(prev);
+			next.delete(id);
+			return next;
+		});
+	};
+
+	const handleDeleteChecked = () => {
+		setItems((prev) => prev.filter((item) => !checkedIds.has(item.id)));
+		setCheckedIds(new Set());
+	};
+
+	/* ── 주문 요약: 체크된 아이템만 집계 ── */
+	const checkedItems = items.filter((item) => checkedIds.has(item.id));
+	const totalPrice = checkedItems.reduce(
+		(acc, item) => acc + item.price * item.quantity,
+		0
+	);
+
+	const formatPrice = (price: number) => price.toLocaleString("ko-KR") + "원";
+
+	return (
+		<div className="bg-[white]">
+			{/* 페이지 헤더 */}
+			<div className="bg-white border-b border-[white]">
+				<div className="max-w-7xl mx-auto px-6 pt-8 pb-5 flex items-center gap-4">
+					<div className="flex items-center gap-2 pl-6">
+						<h1 className="text-xl font-semibold text-gray-900">
+							{cart?.name ?? "장바구니"}
+						</h1>
+						{cart?.type === "shared" && (
+							<span className="text-m font-medium px-2 py-0.5 bg-[#F7F3E9] border border-[#D9CEBC] text-[#7A6E5A] rounded-full">
+								공유
+							</span>
+						)}
+					</div>
+				</div>
+			</div>
+
+			{/* 컨텐츠 영역 */}
+			<div className="max-w-7xl mx-auto px-6 pt-5 pb-4">
+				{items.length === 0 ? (
+					// 빈 장바구니
+					<div className="bg-white rounded-2xl flex flex-col items-center justify-center py-24 gap-5">
+						<div className="w-24 h-24 rounded-full bg-[#F7F3E9] flex items-center justify-center">
+							<ShoppingBag className="w-12 h-12 text-[#C8BFA8]" />
+						</div>
+						<div className="text-center space-y-1.5">
+							<p className="text-xl font-semibold text-gray-800">
+								장바구니가 비어있습니다
+							</p>
+							<p className="text-sm text-gray-500">원하는 상품을 담아보세요!</p>
+						</div>
+						<button
+							onClick={() => navigate("/")}
+							className="mt-2 px-8 py-3 bg-[#F7F3E9] hover:bg-[#F3EEE0] text-gray-900 font-semibold rounded-xl transition-colors text-sm shadow-sm">
+							쇼핑 계속하기
+						</button>
+					</div>
+				) : (
+					// 상품 존재시
+					<div className="flex items-start gap-12">
+						{/* 왼쪽: 상품 카드 리스트 */}
+						<div className="flex-1 min-w-0">
+							{/* 전체 선택 툴바 */}
+							<div className="flex items-center justify-between px-6 py-3 mb-1">
+								<label className="flex items-center gap-2.5 cursor-pointer select-none">
+									<input
+										type="checkbox"
+										checked={isAllChecked}
+										ref={(el) => {
+											if (el) el.indeterminate = isIndeterminate;
+										}}
+										onChange={handleToggleAll}
+										className="w-4 h-4 rounded border-gray-300 accent-gray-800 cursor-pointer"
+									/>
+									<span className="text-sm font-medium text-gray-700">
+										전체 선택
+										<span className="ml-1 text-gray-400">
+											({checkedIds.size}/{items.length})
+										</span>
+									</span>
+								</label>
+
+								{checkedIds.size > 0 && (
+									<button
+										onClick={handleDeleteChecked}
+										className="text-sm text-red-400 hover:text-red-600 transition-colors">
+										선택 삭제
+									</button>
+								)}
+							</div>
+
+							{/* 상품 행 목록 */}
+							<div className="bg-white rounded-2xl overflow-hidden divide-y divide-[#F0EBE0]">
+								{items.map((item) => {
+									const isChecked = checkedIds.has(item.id);
+									return (
+										<div
+											key={item.id}
+											className={`flex items-center gap-5 px-6 py-5 transition-colors ${
+												isChecked ? "bg-white" : "bg-gray-50/60"
+											}`}>
+											{/* 체크박스 */}
+											<input
+												type="checkbox"
+												checked={isChecked}
+												onChange={() => handleToggleItem(item.id)}
+												className="w-4 h-4 shrink-0 rounded border-gray-300 accent-gray-800 cursor-pointer"
+											/>
+
+											{/* 썸네일 */}
+											<div
+												className={`w-20 h-20 rounded-xl overflow-hidden shrink-0 bg-[#F7F3E9] transition-opacity ${!isChecked ? "opacity-40" : ""}`}>
+												<img
+													src={item.thumbnail}
+													alt={item.name}
+													className="w-full h-full object-cover"
+												/>
+											</div>
+
+											{/* 상품 정보 */}
+											<div
+												className={`flex-1 min-w-0 transition-opacity ${!isChecked ? "opacity-40" : ""}`}>
+												<p className="text-base font-medium text-gray-900 truncate">
+													{item.name}
+												</p>
+												<p className="mt-1 text-sm font-semibold text-gray-800">
+													{formatPrice(item.price)}
+												</p>
+											</div>
+
+											{/* 수량 컨트롤 */}
+											<div className="flex items-center gap-2">
+												<button
+													onClick={() => handleDecrease(item.id)}
+													disabled={item.quantity <= 1}
+													className="w-8 h-8 flex items-center justify-center rounded-lg border border-[#D9CEBC] bg-white hover:bg-[#F7F3E9] disabled:opacity-30 disabled:cursor-not-allowed transition-colors">
+													<Minus className="w-3.5 h-3.5 text-gray-600" />
+												</button>
+												<span className="w-8 text-center text-sm font-semibold text-gray-800">
+													{item.quantity}
+												</span>
+												<button
+													onClick={() => handleIncrease(item.id)}
+													className="w-8 h-8 flex items-center justify-center rounded-lg border border-[#D9CEBC] bg-white hover:bg-[#F7F3E9] transition-colors">
+													<Plus className="w-3.5 h-3.5 text-gray-600" />
+												</button>
+											</div>
+
+											{/* 소계 */}
+											<div className="w-24 text-right">
+												<p className="text-sm font-bold text-gray-900">
+													{formatPrice(item.price * item.quantity)}
+												</p>
+											</div>
+
+											{/* 삭제 버튼 */}
+											<button
+												onClick={() => handleDelete(item.id)}
+												className="p-2 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors">
+												<Trash2 className="w-4 h-4" />
+											</button>
+										</div>
+									);
+								})}
+							</div>
+						</div>
+
+						{/* 오른쪽: 주문 요약 패널 (sticky) */}
+						<div className="w-72 shrink-0 sticky top-6">
+							<div className="bg-white rounded-2xl border border-[#EDE9E0] shadow-sm px-6 py-6 flex flex-col gap-4">
+								<h2 className="text-base font-semibold text-gray-900">
+									주문 요약
+								</h2>
+
+								{/* 체크된 상품별 소계 목록 */}
+								<div className="flex flex-col gap-2">
+									{checkedItems.length === 0 ? (
+										<p className="text-sm text-gray-400 text-center py-2">
+											선택된 상품이 없습니다
+										</p>
+									) : (
+										checkedItems.map((item) => (
+											<div
+												key={item.id}
+												className="flex justify-between text-sm text-gray-600">
+												<span className="truncate max-w-[140px]">
+													{item.name}
+												</span>
+												<span className="font-medium text-gray-800 shrink-0">
+													{formatPrice(item.price * item.quantity)}
+												</span>
+											</div>
+										))
+									)}
+								</div>
+
+								<div className="border-t border-[#EDE9E0] pt-6 flex flex-col gap-2.5">
+									<div className="flex justify-between text-sm text-gray-500">
+										<span>선택 상품 수</span>
+										<span>{checkedItems.length}개</span>
+									</div>
+									<div className="flex justify-between items-baseline mt-1">
+										<span className="text-sm font-medium text-gray-700">
+											합계
+										</span>
+										<span className="text-xl font-bold text-gray-900">
+											{formatPrice(totalPrice)}
+										</span>
+									</div>
+								</div>
+
+								<button
+									disabled={checkedItems.length === 0}
+									className="w-full py-3.5 bg-[#F7F3E9] hover:bg-[#F3EEE0] disabled:opacity-40 disabled:cursor-not-allowed text-black font-semibold rounded-xl transition-colors text-sm tracking-wide shadow-sm">
+									주문하기 ({checkedItems.length})
+								</button>
+							</div>
+						</div>
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/src/providers/ModalProvider.tsx
+++ b/src/providers/ModalProvider.tsx
@@ -1,0 +1,73 @@
+import { type ReactNode, lazy, Suspense } from "react";
+import { createPortal } from "react-dom";
+import { useModalOpenState, type ModalKey } from "../store/useCartModalStore";
+
+// lazy 임포트 도입 각 모달은 실제로 open될 때만 번들이 다운로드됨
+const CreateCartModal = lazy(
+	() => import("../components/modals/CreateCartModal")
+);
+const AddToCartModal = lazy(
+	() => import("../components/modals/AddToCartModal")
+);
+const SelectCartModal = lazy(
+	() => import("../components/modals/SelectCartModal")
+);
+
+const MODAL_MAP: Record<
+	ModalKey,
+	React.LazyExoticComponent<React.ComponentType>
+> = {
+	createCart: CreateCartModal,
+	createSharedCart: CreateCartModal,
+	addToCart: AddToCartModal,
+	selectCart: SelectCartModal,
+};
+
+// 중복 렌더링 방지, createCart와 createSharedCart는 같은 컴포넌트이므로 한 번만 렌더링
+const UNIQUE_MODAL_KEYS: ModalKey[] = ["createCart", "addToCart", "selectCart"];
+
+// 단일 모달 키에 대해 open 상태 구독 + Portal 렌더링
+function ModalPortal({
+	modalKey,
+	modalRoot,
+}: {
+	modalKey: ModalKey;
+	modalRoot: Element;
+}) {
+	const isOpen = useModalOpenState(modalKey);
+
+	// createCart 키에서는 createCart OR createSharedCart 중 하나라도 열리면 렌더링
+	const isCreateSharedCartOpen = useModalOpenState("createSharedCart");
+
+	const shouldRender =
+		modalKey === "createCart" ? isOpen || isCreateSharedCartOpen : isOpen;
+
+	if (!shouldRender) return null;
+
+	const ModalComponent = MODAL_MAP[modalKey];
+
+	return createPortal(
+		<Suspense fallback={null}>
+			<ModalComponent />
+		</Suspense>,
+		modalRoot
+	);
+}
+
+export default function ModalProvider({ children }: { children: ReactNode }) {
+	const modalRoot =
+		typeof document !== "undefined"
+			? document.getElementById("modal-root")
+			: null;
+
+	return (
+		<>
+			{children}
+
+			{modalRoot &&
+				UNIQUE_MODAL_KEYS.map((key) => (
+					<ModalPortal key={key} modalKey={key} modalRoot={modalRoot} />
+				))}
+		</>
+	);
+}

--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -3,6 +3,7 @@ import GlobalLayout from "../components/layout/GlobalLayout";
 import MainPage from "../pages/main/MainPage.tsx";
 import LoginPage from "../pages/login/LoginPage.tsx";
 import ProductDetailPage from "../pages/products/ProductDetailPage.tsx";
+import CartDetailPage from "../pages/cart/CartDetailPage.tsx";
 
 export default function AppRouter() {
 	return (
@@ -12,6 +13,7 @@ export default function AppRouter() {
 			<Route element={<GlobalLayout />}>
 				<Route path="/" element={<MainPage />} />
 				<Route path="/product/:id" element={<ProductDetailPage />} />
+				<Route path="/cart" element={<CartDetailPage />} />
 			</Route>
 		</Routes>
 	);

--- a/src/store/useCartModalStore.ts
+++ b/src/store/useCartModalStore.ts
@@ -2,6 +2,13 @@ import { create } from "zustand";
 import { combine } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 
+// ModalKey: ModalProvider에서 lazy 임포트 대상 모달을 식별하는 리터럴 유니온 타입
+export type ModalKey =
+	| "createCart"
+	| "createSharedCart"
+	| "addToCart"
+	| "selectCart";
+
 // 사이드바 장바구니 모달 상태를 관리하는 전용 store
 export const useCartModalStore = create(
 	immer(
@@ -156,4 +163,17 @@ export const useOpenSelectCartModal = () => {
 
 export const useCloseSelectCartModal = () => {
 	return useCartModalStore((state) => state.closeSelectCartModal);
+};
+
+// ModalProvider에서 ModalKey로 해당 모달의 open 상태를 조회하는 유틸 훅
+export const useModalOpenState = (key: ModalKey): boolean => {
+	return useCartModalStore((state) => {
+		const stateMap: Record<ModalKey, boolean> = {
+			createCart: state.isCreateCartModalOpen,
+			createSharedCart: state.isCreateSharedCartModalOpen,
+			addToCart: state.isAddToCartModalOpen,
+			selectCart: state.isSelectCartModalOpen,
+		};
+		return stateMap[key];
+	});
 };


### PR DESCRIPTION
## 🛠️ 설명 (Description)

- 전역 ModalProvider로 포털 기반 렌더링 및 지연 로딩 적용하였습니다.
- 장바구니 상세 페이지 추가 및 사이드바 장바구니 라우팅 연결하였습니다.

## 📝 변경 사항 요약 (Summary)

- `index.html`에 `#modal-root` 추가, DOM 계층 분리
- `src/providers/ModalProvider.tsx` 신규 생성
  - `createPortal` + `lazy` + `Suspense` + `Zustand` 조합
  - `ModalKey` 기반 `MODAL_MAP`으로 모달 확장 용이성 확보
- `GlobalLayout.tsx`에서 모달 관련 코드 전부 제거
- `main.tsx`에 `ModalProvider` 래핑 추가
- `useCartModalStore.ts`에 `ModalKey` 타입 및 `useModalOpenState` 훅 추가

- 장바구니 상세 페이지 `CartDetailPage.tsx` UI 구현
- `mock` 장바구니 데이터에 아이템 구조(`price/quantity/thumbnail`) 확장
- 사이드바에서 장바구니 클릭 시 상세 페이지 이동 로직 추가
- 장바구니 관련 모달 동작 및 레이아웃 일부 정리

## 🔗 관련 이슈 (Related Issues)

- Closes #None
- Related #17

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

## ➕ 추가 정보 (Additional Information)
