### PR TITLE
#21 feature(cart): 장바구니 목록 페이지 UI 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <link rel="icon" type="image/svg+xml" href="/logo.svg" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>공유 장바구니</title>
+  <title>MisePrep | 공유 장바구니</title>
 </head>
 
 <body>

--- a/src/components/cart/CartSection.tsx
+++ b/src/components/cart/CartSection.tsx
@@ -1,0 +1,160 @@
+import { useState } from "react";
+import { ShoppingCart, Users, User, ChevronRight } from "lucide-react";
+import { publicCarts } from "../../mock/cartData";
+import type { PublicCart, CartCategory } from "../../mock/cartData";
+
+// ─────────────────────────────────────────
+// 카테고리 탭 정의 (ProductSection과 동일 순서)
+// ─────────────────────────────────────────
+const cartCategories: { id: CartCategory; label: string }[] = [
+	{ id: "living", label: "생활용품" },
+	{ id: "ingredients", label: "식재료" },
+	{ id: "office", label: "사무용품" },
+	{ id: "camping", label: "캠핑용품" },
+];
+
+// ─────────────────────────────────────────
+// 유틸: 대표 썸네일 반환
+// ─────────────────────────────────────────
+function getRepresentativeThumbnail(items: PublicCart["items"]): string {
+	return items.length > 0
+		? items[0].thumbnail
+		: "https://images.unsplash.com/photo-1506617564039-2f3b650b7010?w=400&q=80";
+}
+
+// ─────────────────────────────────────────
+// 유틸: 장바구니 총 금액 계산
+// ─────────────────────────────────────────
+function calcTotalPrice(items: PublicCart["items"]): number {
+	return items.reduce((sum, item) => sum + item.price * item.quantity, 0);
+}
+
+// ─────────────────────────────────────────
+// CartCard 컴포넌트
+// ─────────────────────────────────────────
+function CartCard({ cart }: { cart: PublicCart }) {
+	const isShared = cart.type === "shared";
+	const totalPrice = calcTotalPrice(cart.items);
+	const thumbnail = getRepresentativeThumbnail(cart.items);
+
+	return (
+		<div className="group flex flex-col cursor-pointer">
+			{/* 대표 상품 이미지 */}
+			<div
+				className="relative w-full rounded-xl overflow-hidden mb-3"
+				style={{ aspectRatio: "1 / 1" }}>
+				<img
+					src={thumbnail}
+					alt={cart.name}
+					className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
+				/>
+			</div>
+
+			{/* 장바구니 정보 */}
+			<div className="flex flex-col gap-1">
+				{/* 장바구니 이름 + 개인/공유 뱃지 (이름 오른쪽) */}
+				<div className="flex items-center gap-1.5">
+					<ShoppingCart className="w-3.5 h-3.5 text-[#C8A97A] shrink-0" />
+					<p className="text-sm font-semibold text-gray-900 leading-snug line-clamp-1 flex-1">
+						{cart.name}
+					</p>
+					<span
+						className={`inline-flex items-center gap-0.5 px-2 py-0.5 rounded-full text-xs font-semibold shrink-0 ${
+							isShared ? "bg-[#D4B896] text-white" : "bg-gray-100 text-gray-600"
+						}`}>
+						{isShared ? (
+							<Users className="w-3 h-3" />
+						) : (
+							<User className="w-3 h-3" />
+						)}
+						{isShared ? "공유" : "개인"}
+					</span>
+				</div>
+
+				{/* 소유자 닉네임 + 담긴 상품 개수 */}
+				<p className="text-xs text-gray-400">
+					<span className="font-medium text-gray-500">{cart.ownerName}</span>
+					{" · "}담긴 상품{" "}
+					<span className="font-medium text-gray-600">
+						{cart.items.length}개
+					</span>
+				</p>
+
+				{/* 총 금액 */}
+				<p className="text-base font-bold text-gray-900 mt-0.5">
+					{totalPrice.toLocaleString()}원
+				</p>
+			</div>
+		</div>
+	);
+}
+
+// ─────────────────────────────────────────
+// CartSection (메인 페이지 노출용)
+// ─────────────────────────────────────────
+export default function CartSection() {
+	const [activeCategory, setActiveCategory] = useState<CartCategory>(
+		cartCategories[0].id
+	);
+
+	// 선택된 카테고리로 필터링 후 인기순(likeCount 내림차순) 정렬, 최대 8개
+	const filteredCarts = publicCarts
+		.filter((c) => c.category === activeCategory)
+		.sort((a, b) => b.likeCount - a.likeCount)
+		.slice(0, 8);
+
+	const currentCategory = cartCategories.find((c) => c.id === activeCategory)!;
+
+	return (
+		<section className="w-full bg-white py-16">
+			<div className="max-w-7xl mx-auto px-6">
+				{/* 섹션 타이틀 */}
+				<h2 className="text-2xl font-bold text-gray-900 mb-5">
+					가장 인기있는 장바구니
+				</h2>
+
+				{/* 카테고리 탭 */}
+				<div className="flex border-b border-gray-200 mb-6">
+					{cartCategories.map((cat) => (
+						<button
+							key={cat.id}
+							onClick={() => setActiveCategory(cat.id)}
+							className={`px-5 py-2.5 text-sm font-medium rounded-t transition-all whitespace-nowrap ${
+								activeCategory === cat.id
+									? "bg-[#F6F0E4] text-gray-900 font-bold"
+									: "text-gray-500 hover:text-gray-800"
+							}`}>
+							{cat.label}
+						</button>
+					))}
+				</div>
+
+				{/* 장바구니 그리드: 4열 */}
+				{filteredCarts.length > 0 ? (
+					<div className="grid grid-cols-4 gap-x-6 gap-y-16">
+						{filteredCarts.map((cart) => (
+							<CartCard key={cart.id} cart={cart} />
+						))}
+					</div>
+				) : (
+					<div className="flex flex-col items-center justify-center py-24 gap-3 text-gray-400">
+						<ShoppingCart className="w-12 h-12 opacity-30" />
+						<p className="text-sm">
+							{currentCategory.label} 카테고리의 인기 장바구니가 없습니다.
+						</p>
+					</div>
+				)}
+
+				{/* 전체보기 버튼 */}
+				{filteredCarts.length > 0 && (
+					<div className="flex justify-center mt-10">
+						<button className="px-16 py-4 border border-gray-200 rounded-2xl flex items-center justify-center gap-1.5 text-gray-500 font-medium hover:bg-[#F6F0E4] hover:border-[#D4B896] transition-all">
+							<span>{currentCategory.label} 장바구니 전체보기</span>
+							<ChevronRight className="w-4 h-4" />
+						</button>
+					</div>
+				)}
+			</div>
+		</section>
+	);
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -9,7 +9,7 @@ export default function Footer() {
 						<div className="flex items-center gap-2">
 							<ShoppingCart className="w-5 h-5 text-gray-800" />
 							<span className="text-lg font-semibold text-gray-900">
-								공유장바구니
+								MisePrep | 공유 장바구니
 							</span>
 						</div>
 						<p className="text-sm text-gray-600">
@@ -45,7 +45,7 @@ export default function Footer() {
 				</div>
 
 				<div className="flex flex-col gap-3 text-sm text-gray-600 md:flex-row md:items-center md:justify-between">
-					<p>대전광역시 한밭대학교 | ©2026 gongjang-mall</p>
+					<p>대전광역시 한밭대학교 | ©2026 MisePrep</p>
 				</div>
 			</div>
 		</footer>

--- a/src/components/layout/MainHeader.tsx
+++ b/src/components/layout/MainHeader.tsx
@@ -7,23 +7,23 @@ export default function MainHeader() {
 	const handleAllCategory = () => {
 		alert("전체 카테고리 메뉴는 현재 구현 예정입니다.");
 	};
+	const handleCart = () => {
+		navigate("/cart");
+	};
 	const handleBest = () => {
 		alert("베스트 상품 페이지는 현재 구현 예정입니다.");
-	};
-	const handleSale = () => {
-		alert("할인 상품 페이지는 현재 구현 예정입니다.");
 	};
 	const handleDaily = () => {
 		alert("생활용품 카테고리는 현재 구현 예정입니다.");
 	};
-	const handleKitchen = () => {
-		alert("주방용품 카테고리는 현재 구현 예정입니다.");
+	const handleIngredients = () => {
+		alert("식재료 카테고리는 현재 구현 예정입니다.");
 	};
 	const handleOffice = () => {
 		alert("사무용품 카테고리는 현재 구현 예정입니다.");
 	};
-	const handleFashion = () => {
-		alert("패션의류/잡화 카테고리는 현재 구현 예정입니다.");
+	const handleCamping = () => {
+		alert("캠핑용품 카테고리는 현재 구현 예정입니다.");
 	};
 	const handleSearch = () => {
 		alert("검색 기능은 현재 구현 예정입니다.");
@@ -66,14 +66,14 @@ export default function MainHeader() {
 						<span>전체 카테고리</span>
 					</button>
 					<button
+						onClick={handleCart}
+						className="px-3 py-1.5 text-gray-800 hover:text-gray-900 hover:bg-gray-100 font-medium rounded transition-colors">
+						장바구니
+					</button>
+					<button
 						onClick={handleBest}
 						className="px-3 py-1.5 text-gray-800 hover:text-gray-900 hover:bg-gray-100 font-medium rounded transition-colors">
 						베스트
-					</button>
-					<button
-						onClick={handleSale}
-						className="px-3 py-1.5 text-gray-800 hover:text-gray-900 hover:bg-gray-100 font-medium rounded transition-colors">
-						할인
 					</button>
 					<button
 						onClick={handleDaily}
@@ -81,9 +81,9 @@ export default function MainHeader() {
 						생활용품
 					</button>
 					<button
-						onClick={handleKitchen}
+						onClick={handleIngredients}
 						className="px-3 py-1.5 text-gray-800 hover:text-gray-900 hover:bg-gray-100 font-medium rounded transition-colors">
-						주방용품
+						식재료
 					</button>
 					<button
 						onClick={handleOffice}
@@ -91,9 +91,9 @@ export default function MainHeader() {
 						사무용품
 					</button>
 					<button
-						onClick={handleFashion}
+						onClick={handleCamping}
 						className="px-3 py-1.5 text-gray-800 hover:text-gray-900 hover:bg-gray-100 font-medium rounded transition-colors">
-						패션의류/잡화
+						캠핑용품
 					</button>
 				</nav>
 			</div>

--- a/src/components/layout/ScrollToTop.tsx
+++ b/src/components/layout/ScrollToTop.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function ScrollToTop() {
+	const { pathname } = useLocation();
+
+	useEffect(() => {
+		window.scrollTo(0, 0);
+	}, [pathname]);
+
+	return null;
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -18,7 +18,7 @@ export default function Sidebar() {
 
 	const handleCartClick = (cartId: number, cartType: "personal" | "shared") => {
 		closeSidebar();
-		navigate(`/cart?id=${cartId}&type=${cartType}`);
+		navigate(`/cart/detail?id=${cartId}&type=${cartType}`);
 	};
 
 	return (

--- a/src/mock/cartData.ts
+++ b/src/mock/cartData.ts
@@ -8,19 +8,37 @@ export interface CartItem {
 	thumbnail: string;
 }
 
-// 개인 장바구니 타입
+// 개인 장바구니 타입 (내 장바구니 - private)
 export interface PersonalCart {
 	id: number;
 	name: string;
 	items: CartItem[];
 }
 
-// 공유 장바구니 타입
+// 공유 장바구니 타입 (내 장바구니 - shared with team)
 export interface SharedCart {
 	id: number;
 	name: string;
 	items: CartItem[];
 }
+
+// 공개 장바구니 카테고리 (ProductSection 카테고리와 동일)
+export type CartCategory = "living" | "ingredients" | "office" | "camping";
+
+// 공개 장바구니 타입 (다른 사람들의 public 장바구니)
+export interface PublicCart {
+	id: number;
+	ownerName: string; // 장바구니 소유자 닉네임
+	name: string;
+	type: "personal" | "shared"; // 소유자 기준 개인 or 공유 여부
+	category: CartCategory; // 장바구니 주요 카테고리
+	items: CartItem[];
+	likeCount: number; // 인기도 지표
+}
+
+// ─────────────────────────────────────────
+// 내 장바구니 데이터
+// ─────────────────────────────────────────
 
 export const personalCarts: PersonalCart[] = [
 	{
@@ -80,6 +98,283 @@ export const sharedCarts: SharedCart[] = [
 				quantity: 3,
 				thumbnail:
 					"https://images.unsplash.com/photo-1568667256549-094345857637?w=200&q=80",
+			},
+		],
+	},
+];
+
+// ─────────────────────────────────────────
+// 다른 사람들의 공개(public) 장바구니 데이터
+// → 메인 페이지 "가장 인기있는 장바구니" 섹션에서 사용
+// ─────────────────────────────────────────
+
+export const publicCarts: PublicCart[] = [
+	{
+		id: 101,
+		ownerName: "김민준",
+		name: "주방 필수템 모음",
+		type: "personal",
+		category: "living",
+		likeCount: 342,
+		items: [
+			{
+				id: 10,
+				productId: 301,
+				name: "스테인리스 주방 가위",
+				price: 12900,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1556909114-f6e7ad7d3136?w=400&q=80",
+			},
+			{
+				id: 11,
+				productId: 302,
+				name: "실리콘 주걱 세트 3P",
+				price: 8500,
+				quantity: 2,
+				thumbnail:
+					"https://images.unsplash.com/photo-1556909114-f6e7ad7d3136?w=400&q=80",
+			},
+			{
+				id: 12,
+				productId: 303,
+				name: "대나무 도마",
+				price: 15000,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1556909114-f6e7ad7d3136?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 102,
+		ownerName: "이서연",
+		name: "자취방 생활용품 세트",
+		type: "personal",
+		category: "living",
+		likeCount: 287,
+		items: [
+			{
+				id: 13,
+				productId: 401,
+				name: "크리넥스 티슈 250매×6입",
+				price: 12900,
+				quantity: 2,
+				thumbnail:
+					"https://images.unsplash.com/photo-1584556812952-905ffd0c611a?w=400&q=80",
+			},
+			{
+				id: 14,
+				productId: 402,
+				name: "샤워기 헤드 교체용",
+				price: 19800,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1584622781564-1d987f7333c1?w=400&q=80",
+			},
+			{
+				id: 15,
+				productId: 403,
+				name: "행거 수납봉 2P",
+				price: 6500,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1558618666-fcd25c85cd64?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 103,
+		ownerName: "박지훈 팀",
+		name: "개발팀 사무용품 공동구매",
+		type: "shared",
+		category: "office",
+		likeCount: 215,
+		items: [
+			{
+				id: 16,
+				productId: 501,
+				name: "무선 마우스 M185",
+				price: 19900,
+				quantity: 8,
+				thumbnail:
+					"https://images.unsplash.com/photo-1527864550417-7fd91fc51a46?w=400&q=80",
+			},
+			{
+				id: 17,
+				productId: 502,
+				name: "포스트잇 6색 6패드",
+				price: 7900,
+				quantity: 10,
+				thumbnail:
+					"https://images.unsplash.com/photo-1586075010923-2dd4570fb338?w=400&q=80",
+			},
+			{
+				id: 18,
+				productId: 503,
+				name: "A4 복사용지 80g 500매",
+				price: 5900,
+				quantity: 5,
+				thumbnail:
+					"https://images.unsplash.com/photo-1568702846914-96b305d2ead1?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 104,
+		ownerName: "최유나",
+		name: "캠핑 준비물 체크리스트",
+		type: "personal",
+		category: "camping",
+		likeCount: 198,
+		items: [
+			{
+				id: 19,
+				productId: 601,
+				name: "원터치 팝업 텐트 3-4인용",
+				price: 49900,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1504280390367-361c6d9f38f4?w=400&q=80",
+			},
+			{
+				id: 20,
+				productId: 602,
+				name: "캠핑용 폴딩 체어 세트 (2P)",
+				price: 29800,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1523906834658-6e24ef2386f9?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 105,
+		ownerName: "정도윤 팀",
+		name: "동아리 MT 공동구매",
+		type: "shared",
+		category: "ingredients",
+		likeCount: 176,
+		items: [
+			{
+				id: 21,
+				productId: 701,
+				name: "진라면 순한맛 5입",
+				price: 3200,
+				quantity: 20,
+				thumbnail:
+					"https://images.unsplash.com/photo-1612929633738-8fe44f7ec841?w=400&q=80",
+			},
+			{
+				id: 22,
+				productId: 702,
+				name: "햇반 210g×12개",
+				price: 14900,
+				quantity: 5,
+				thumbnail:
+					"https://images.unsplash.com/photo-1536304929831-ee1ca9d44906?w=400&q=80",
+			},
+			{
+				id: 23,
+				productId: 703,
+				name: "참치 135g×4캔",
+				price: 8900,
+				quantity: 10,
+				thumbnail:
+					"https://images.unsplash.com/photo-1534483509719-3feaee7c30da?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 106,
+		ownerName: "한소희",
+		name: "신학기 사무용품 준비",
+		type: "personal",
+		category: "office",
+		likeCount: 154,
+		items: [
+			{
+				id: 24,
+				productId: 801,
+				name: "볼펜 0.5mm 10자루",
+				price: 3900,
+				quantity: 2,
+				thumbnail:
+					"https://images.unsplash.com/photo-1585336261022-680e295ce3fe?w=400&q=80",
+			},
+			{
+				id: 25,
+				productId: 802,
+				name: "형광펜 6색 세트",
+				price: 3900,
+				quantity: 3,
+				thumbnail:
+					"https://images.unsplash.com/photo-1513542789411-b6a5d4f31634?w=400&q=80",
+			},
+			{
+				id: 26,
+				productId: 803,
+				name: "USB 메모리 64GB",
+				price: 12900,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1618410320928-25228d811631?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 107,
+		ownerName: "오승환",
+		name: "홈카페 도구 모음",
+		type: "personal",
+		category: "living",
+		likeCount: 143,
+		items: [
+			{
+				id: 27,
+				productId: 901,
+				name: "에스프레소 머신용 분쇄기",
+				price: 89000,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1495474472287-4d71bcdd2085?w=400&q=80",
+			},
+			{
+				id: 28,
+				productId: 902,
+				name: "스테인리스 텀블러 500ml",
+				price: 22000,
+				quantity: 2,
+				thumbnail:
+					"https://images.unsplash.com/photo-1514228742587-6b1558fcca3d?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 108,
+		ownerName: "임수진 팀",
+		name: "학과 연구실 간식 공동주문",
+		type: "shared",
+		category: "ingredients",
+		likeCount: 129,
+		items: [
+			{
+				id: 29,
+				productId: 1001,
+				name: "국내산 계란 30구",
+				price: 6900,
+				quantity: 3,
+				thumbnail:
+					"https://images.unsplash.com/photo-1582722872445-44dc5f7e3c8f?w=400&q=80",
+			},
+			{
+				id: 30,
+				productId: 1002,
+				name: "로제파스타 소스 200g",
+				price: 4500,
+				quantity: 5,
+				thumbnail:
+					"https://images.unsplash.com/photo-1621996346565-e3dbc646d9a9?w=400&q=80",
 			},
 		],
 	},

--- a/src/mock/cartData.ts
+++ b/src/mock/cartData.ts
@@ -105,10 +105,12 @@ export const sharedCarts: SharedCart[] = [
 
 // ─────────────────────────────────────────
 // 다른 사람들의 공개(public) 장바구니 데이터
-// → 메인 페이지 "가장 인기있는 장바구니" 섹션에서 사용
+// → 메인 페이지 "가장 인기있는 장바구니" & CartListPage에서 사용
+// 카테고리별 최소 10개 이상 보유
 // ─────────────────────────────────────────
 
 export const publicCarts: PublicCart[] = [
+	// ── 생활용품 (living) ──────────────────────────
 	{
 		id: 101,
 		ownerName: "김민준",
@@ -184,70 +186,213 @@ export const publicCarts: PublicCart[] = [
 		],
 	},
 	{
-		id: 103,
-		ownerName: "박지훈 팀",
-		name: "개발팀 사무용품 공동구매",
-		type: "shared",
-		category: "office",
-		likeCount: 215,
+		id: 107,
+		ownerName: "오승환",
+		name: "홈카페 도구 모음",
+		type: "personal",
+		category: "living",
+		likeCount: 143,
 		items: [
 			{
-				id: 16,
-				productId: 501,
-				name: "무선 마우스 M185",
-				price: 19900,
-				quantity: 8,
+				id: 27,
+				productId: 901,
+				name: "에스프레소 머신용 분쇄기",
+				price: 89000,
+				quantity: 1,
 				thumbnail:
-					"https://images.unsplash.com/photo-1527864550417-7fd91fc51a46?w=400&q=80",
+					"https://images.unsplash.com/photo-1495474472287-4d71bcdd2085?w=400&q=80",
 			},
 			{
-				id: 17,
-				productId: 502,
-				name: "포스트잇 6색 6패드",
-				price: 7900,
-				quantity: 10,
+				id: 28,
+				productId: 902,
+				name: "스테인리스 텀블러 500ml",
+				price: 22000,
+				quantity: 2,
 				thumbnail:
-					"https://images.unsplash.com/photo-1586075010923-2dd4570fb338?w=400&q=80",
-			},
-			{
-				id: 18,
-				productId: 503,
-				name: "A4 복사용지 80g 500매",
-				price: 5900,
-				quantity: 5,
-				thumbnail:
-					"https://images.unsplash.com/photo-1568702846914-96b305d2ead1?w=400&q=80",
+					"https://images.unsplash.com/photo-1514228742587-6b1558fcca3d?w=400&q=80",
 			},
 		],
 	},
 	{
-		id: 104,
-		ownerName: "최유나",
-		name: "캠핑 준비물 체크리스트",
+		id: 111,
+		ownerName: "윤지호",
+		name: "욕실 청결 용품 세트",
 		type: "personal",
-		category: "camping",
-		likeCount: 198,
+		category: "living",
+		likeCount: 118,
 		items: [
 			{
-				id: 19,
-				productId: 601,
-				name: "원터치 팝업 텐트 3-4인용",
-				price: 49900,
-				quantity: 1,
+				id: 31,
+				productId: 1101,
+				name: "페리오 치약 세트 3입",
+				price: 7900,
+				quantity: 2,
 				thumbnail:
-					"https://images.unsplash.com/photo-1504280390367-361c6d9f38f4?w=400&q=80",
+					"https://images.unsplash.com/photo-1559056199-641a0ac8b55e?w=400&q=80",
 			},
 			{
-				id: 20,
-				productId: 602,
-				name: "캠핑용 폴딩 체어 세트 (2P)",
-				price: 29800,
-				quantity: 1,
+				id: 32,
+				productId: 1102,
+				name: "유한락스 표백제 2L",
+				price: 3900,
+				quantity: 2,
 				thumbnail:
-					"https://images.unsplash.com/photo-1523906834658-6e24ef2386f9?w=400&q=80",
+					"https://images.unsplash.com/photo-1585421514284-efb74c2b69ba?w=400&q=80",
 			},
 		],
 	},
+	{
+		id: 112,
+		ownerName: "강미래",
+		name: "신혼집 주방 세팅",
+		type: "shared",
+		category: "living",
+		likeCount: 205,
+		items: [
+			{
+				id: 33,
+				productId: 1103,
+				name: "해피바스 바디워시 500ml",
+				price: 6900,
+				quantity: 3,
+				thumbnail:
+					"https://images.unsplash.com/photo-1556228578-0d85b1a4d571?w=400&q=80",
+			},
+			{
+				id: 34,
+				productId: 1104,
+				name: "순수한면 생리대 중형 32매",
+				price: 8900,
+				quantity: 2,
+				thumbnail:
+					"https://images.unsplash.com/photo-1583947215259-38e31be8751f?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 113,
+		ownerName: "박현우",
+		name: "봄맞이 청소 용품",
+		type: "personal",
+		category: "living",
+		likeCount: 167,
+		items: [
+			{
+				id: 35,
+				productId: 1105,
+				name: "데일리 모이스처 로션 200ml",
+				price: 18900,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1611930022073-b7a4ba5fcccd?w=400&q=80",
+			},
+			{
+				id: 36,
+				productId: 1106,
+				name: "쓰레기봉투 20L×50매",
+				price: 5900,
+				quantity: 3,
+				thumbnail:
+					"https://images.unsplash.com/photo-1610141189012-7f4eaa5e3505?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 114,
+		ownerName: "최하은",
+		name: "여름 보습 스킨케어",
+		type: "personal",
+		category: "living",
+		likeCount: 136,
+		items: [
+			{
+				id: 37,
+				productId: 1107,
+				name: "선크림 SPF50+ 50ml",
+				price: 24000,
+				quantity: 2,
+				thumbnail:
+					"https://images.unsplash.com/photo-1556228578-0d85b1a4d571?w=400&q=80",
+			},
+			{
+				id: 38,
+				productId: 1108,
+				name: "알로에 수딩 젤 300ml",
+				price: 9900,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1556228453-efd6c1ff04f6?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 115,
+		ownerName: "임준서 팀",
+		name: "기숙사 공동 생필품",
+		type: "shared",
+		category: "living",
+		likeCount: 182,
+		items: [
+			{
+				id: 39,
+				productId: 1109,
+				name: "스카치 투명테이프 3입",
+				price: 4500,
+				quantity: 5,
+				thumbnail:
+					"https://images.unsplash.com/photo-1586380951230-e6703d9f6833?w=400&q=80",
+			},
+			{
+				id: 40,
+				productId: 1110,
+				name: "크리넥스 티슈 250매×6입",
+				price: 12900,
+				quantity: 3,
+				thumbnail:
+					"https://images.unsplash.com/photo-1584556812952-905ffd0c611a?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 116,
+		ownerName: "정수아",
+		name: "인테리어 소품 쇼핑",
+		type: "personal",
+		category: "living",
+		likeCount: 90,
+		items: [
+			{
+				id: 41,
+				productId: 1111,
+				name: "LED 무드등 소형",
+				price: 15000,
+				quantity: 2,
+				thumbnail:
+					"https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 117,
+		ownerName: "한도현",
+		name: "반려동물 용품 세트",
+		type: "personal",
+		category: "living",
+		likeCount: 74,
+		items: [
+			{
+				id: 42,
+				productId: 1112,
+				name: "강아지 간식 100g",
+				price: 8500,
+				quantity: 3,
+				thumbnail:
+					"https://images.unsplash.com/photo-1587300003388-59208cc962cb?w=400&q=80",
+			},
+		],
+	},
+
+	// ── 식재료 (ingredients) ───────────────────────
 	{
 		id: 105,
 		ownerName: "정도윤 팀",
@@ -282,6 +427,261 @@ export const publicCarts: PublicCart[] = [
 				quantity: 10,
 				thumbnail:
 					"https://images.unsplash.com/photo-1534483509719-3feaee7c30da?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 108,
+		ownerName: "임수진 팀",
+		name: "학과 연구실 간식 공동주문",
+		type: "shared",
+		category: "ingredients",
+		likeCount: 129,
+		items: [
+			{
+				id: 29,
+				productId: 1001,
+				name: "국내산 계란 30구",
+				price: 6900,
+				quantity: 3,
+				thumbnail:
+					"https://images.unsplash.com/photo-1582722872445-44dc5f7e3c8f?w=400&q=80",
+			},
+			{
+				id: 30,
+				productId: 1002,
+				name: "로제파스타 소스 200g",
+				price: 4500,
+				quantity: 5,
+				thumbnail:
+					"https://images.unsplash.com/photo-1621996346565-e3dbc646d9a9?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 121,
+		ownerName: "송민아",
+		name: "주말 바베큐 파티 재료",
+		type: "shared",
+		category: "ingredients",
+		likeCount: 241,
+		items: [
+			{
+				id: 51,
+				productId: 2001,
+				name: "한우 불고기 밀키트 450g",
+				price: 12900,
+				quantity: 3,
+				thumbnail:
+					"https://images.unsplash.com/photo-1763140446057-9becaa30b868?w=400&q=80",
+			},
+			{
+				id: 52,
+				productId: 2002,
+				name: "냉동 새우 500g",
+				price: 9900,
+				quantity: 2,
+				thumbnail:
+					"https://images.unsplash.com/photo-1565680018434-b513d5e5fd47?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 122,
+		ownerName: "권지훈",
+		name: "건강 식단 일주일치",
+		type: "personal",
+		category: "ingredients",
+		likeCount: 195,
+		items: [
+			{
+				id: 53,
+				productId: 2003,
+				name: "국산콩 두부 300g×2입",
+				price: 3480,
+				quantity: 5,
+				thumbnail:
+					"https://images.unsplash.com/photo-1557142046-c704a3adf364?w=400&q=80",
+			},
+			{
+				id: 54,
+				productId: 2004,
+				name: "현미밥 즉석 18개입",
+				price: 18900,
+				quantity: 2,
+				thumbnail:
+					"https://images.unsplash.com/photo-1536304929831-ee1ca9d44906?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 123,
+		ownerName: "박지은",
+		name: "자취 초보 냉장고 채우기",
+		type: "personal",
+		category: "ingredients",
+		likeCount: 163,
+		items: [
+			{
+				id: 55,
+				productId: 2005,
+				name: "햇반 210g×12개",
+				price: 14900,
+				quantity: 2,
+				thumbnail:
+					"https://images.unsplash.com/photo-1536304929831-ee1ca9d44906?w=400&q=80",
+			},
+			{
+				id: 56,
+				productId: 2006,
+				name: "국내산 계란 30구",
+				price: 6900,
+				quantity: 2,
+				thumbnail:
+					"https://images.unsplash.com/photo-1582722872445-44dc5f7e3c8f?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 124,
+		ownerName: "이찬우 팀",
+		name: "회사 점심 도시락 재료",
+		type: "shared",
+		category: "ingredients",
+		likeCount: 148,
+		items: [
+			{
+				id: 57,
+				productId: 2007,
+				name: "참치 135g×4캔",
+				price: 8900,
+				quantity: 5,
+				thumbnail:
+					"https://images.unsplash.com/photo-1534483509719-3feaee7c30da?w=400&q=80",
+			},
+			{
+				id: 58,
+				productId: 2008,
+				name: "진라면 순한맛 5입",
+				price: 3200,
+				quantity: 10,
+				thumbnail:
+					"https://images.unsplash.com/photo-1612929633738-8fe44f7ec841?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 125,
+		ownerName: "최수현",
+		name: "다이어트 식품 모음",
+		type: "personal",
+		category: "ingredients",
+		likeCount: 112,
+		items: [
+			{
+				id: 59,
+				productId: 2009,
+				name: "로제파스타 소스 200g",
+				price: 4500,
+				quantity: 3,
+				thumbnail:
+					"https://images.unsplash.com/photo-1621996346565-e3dbc646d9a9?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 126,
+		ownerName: "조민혁",
+		name: "라면 마니아 컬렉션",
+		type: "personal",
+		category: "ingredients",
+		likeCount: 98,
+		items: [
+			{
+				id: 60,
+				productId: 2010,
+				name: "진라면 순한맛 5입",
+				price: 3200,
+				quantity: 6,
+				thumbnail:
+					"https://images.unsplash.com/photo-1612929633738-8fe44f7ec841?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 127,
+		ownerName: "신예은",
+		name: "채식 식단 장보기",
+		type: "personal",
+		category: "ingredients",
+		likeCount: 85,
+		items: [
+			{
+				id: 61,
+				productId: 2011,
+				name: "국산콩 두부 300g×2입",
+				price: 3480,
+				quantity: 4,
+				thumbnail:
+					"https://images.unsplash.com/photo-1557142046-c704a3adf364?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 128,
+		ownerName: "문성현 팀",
+		name: "야유회 단체 식재료",
+		type: "shared",
+		category: "ingredients",
+		likeCount: 71,
+		items: [
+			{
+				id: 62,
+				productId: 2012,
+				name: "냉동 새우 500g",
+				price: 9900,
+				quantity: 4,
+				thumbnail:
+					"https://images.unsplash.com/photo-1565680018434-b513d5e5fd47?w=400&q=80",
+			},
+		],
+	},
+
+	// ── 사무용품 (office) ──────────────────────────
+	{
+		id: 103,
+		ownerName: "박지훈 팀",
+		name: "개발팀 사무용품 공동구매",
+		type: "shared",
+		category: "office",
+		likeCount: 215,
+		items: [
+			{
+				id: 16,
+				productId: 501,
+				name: "무선 마우스 M185",
+				price: 19900,
+				quantity: 8,
+				thumbnail:
+					"https://images.unsplash.com/photo-1527864550417-7fd91fc51a46?w=400&q=80",
+			},
+			{
+				id: 17,
+				productId: 502,
+				name: "포스트잇 6색 6패드",
+				price: 7900,
+				quantity: 10,
+				thumbnail:
+					"https://images.unsplash.com/photo-1586075010923-2dd4570fb338?w=400&q=80",
+			},
+			{
+				id: 18,
+				productId: 503,
+				name: "A4 복사용지 80g 500매",
+				price: 5900,
+				quantity: 5,
+				thumbnail:
+					"https://images.unsplash.com/photo-1568702846914-96b305d2ead1?w=400&q=80",
 			},
 		],
 	},
@@ -323,58 +723,1481 @@ export const publicCarts: PublicCart[] = [
 		],
 	},
 	{
-		id: 107,
-		ownerName: "오승환",
-		name: "홈카페 도구 모음",
+		id: 131,
+		ownerName: "김도윤",
+		name: "재택근무 홈오피스 세팅",
 		type: "personal",
-		category: "living",
-		likeCount: 143,
+		category: "office",
+		likeCount: 288,
 		items: [
 			{
-				id: 27,
-				productId: 901,
-				name: "에스프레소 머신용 분쇄기",
-				price: 89000,
+				id: 71,
+				productId: 3001,
+				name: "무선 마우스 M185",
+				price: 19900,
 				quantity: 1,
 				thumbnail:
-					"https://images.unsplash.com/photo-1495474472287-4d71bcdd2085?w=400&q=80",
+					"https://images.unsplash.com/photo-1527864550417-7fd91fc51a46?w=400&q=80",
 			},
 			{
-				id: 28,
-				productId: 902,
-				name: "스테인리스 텀블러 500ml",
-				price: 22000,
+				id: 72,
+				productId: 3002,
+				name: "USB 메모리 64GB",
+				price: 12900,
 				quantity: 2,
 				thumbnail:
-					"https://images.unsplash.com/photo-1514228742587-6b1558fcca3d?w=400&q=80",
+					"https://images.unsplash.com/photo-1618410320928-25228d811631?w=400&q=80",
 			},
 		],
 	},
 	{
-		id: 108,
-		ownerName: "임수진 팀",
-		name: "학과 연구실 간식 공동주문",
+		id: 132,
+		ownerName: "이하나 팀",
+		name: "스터디 그룹 공통 문구",
 		type: "shared",
-		category: "ingredients",
-		likeCount: 129,
+		category: "office",
+		likeCount: 173,
 		items: [
 			{
-				id: 29,
-				productId: 1001,
-				name: "국내산 계란 30구",
+				id: 73,
+				productId: 3003,
+				name: "포스트잇 76×76mm 6색 6패드",
+				price: 7900,
+				quantity: 5,
+				thumbnail:
+					"https://images.unsplash.com/photo-1586075010923-2dd4570fb338?w=400&q=80",
+			},
+			{
+				id: 74,
+				productId: 3004,
+				name: "볼펜 0.5mm 10자루",
+				price: 3900,
+				quantity: 4,
+				thumbnail:
+					"https://images.unsplash.com/photo-1585336261022-680e295ce3fe?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 133,
+		ownerName: "정우성",
+		name: "문서 정리 키트",
+		type: "personal",
+		category: "office",
+		likeCount: 142,
+		items: [
+			{
+				id: 75,
+				productId: 3005,
+				name: "투명 파일 케이스 20개입",
+				price: 4900,
+				quantity: 3,
+				thumbnail:
+					"https://images.unsplash.com/photo-1586281380349-632531db7ed4?w=400&q=80",
+			},
+			{
+				id: 76,
+				productId: 3006,
+				name: "스테이플러 대용량 No.10",
+				price: 6900,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1583485088034-697b5bc54ccd?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 134,
+		ownerName: "황소연",
+		name: "데스크 셋업 미니멀",
+		type: "personal",
+		category: "office",
+		likeCount: 126,
+		items: [
+			{
+				id: 77,
+				productId: 3007,
+				name: "A4 복사용지 80g 500매",
+				price: 5900,
+				quantity: 2,
+				thumbnail:
+					"https://images.unsplash.com/photo-1568702846914-96b305d2ead1?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 135,
+		ownerName: "안재현 팀",
+		name: "사무실 이사 용품",
+		type: "shared",
+		category: "office",
+		likeCount: 108,
+		items: [
+			{
+				id: 78,
+				productId: 3008,
+				name: "형광펜 6색 세트",
+				price: 3900,
+				quantity: 6,
+				thumbnail:
+					"https://images.unsplash.com/photo-1513542789411-b6a5d4f31634?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 136,
+		ownerName: "류지민",
+		name: "수험생 필기 세트",
+		type: "personal",
+		category: "office",
+		likeCount: 93,
+		items: [
+			{
+				id: 79,
+				productId: 3009,
+				name: "볼펜 0.5mm 10자루",
+				price: 3900,
+				quantity: 3,
+				thumbnail:
+					"https://images.unsplash.com/photo-1585336261022-680e295ce3fe?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 137,
+		ownerName: "오미래",
+		name: "프리랜서 홈오피스",
+		type: "personal",
+		category: "office",
+		likeCount: 78,
+		items: [
+			{
+				id: 80,
+				productId: 3010,
+				name: "무선 마우스 M185",
+				price: 19900,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1527864550417-7fd91fc51a46?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 138,
+		ownerName: "조현석 팀",
+		name: "팀 프로젝트 공용 문구",
+		type: "shared",
+		category: "office",
+		likeCount: 65,
+		items: [
+			{
+				id: 81,
+				productId: 3011,
+				name: "포스트잇 76×76mm 6색 6패드",
+				price: 7900,
+				quantity: 3,
+				thumbnail:
+					"https://images.unsplash.com/photo-1586075010923-2dd4570fb338?w=400&q=80",
+			},
+		],
+	},
+
+	// ── 캠핑용품 (camping) ─────────────────────────
+	{
+		id: 104,
+		ownerName: "최유나",
+		name: "캠핑 준비물 체크리스트",
+		type: "personal",
+		category: "camping",
+		likeCount: 198,
+		items: [
+			{
+				id: 19,
+				productId: 601,
+				name: "원터치 팝업 텐트 3-4인용",
+				price: 49900,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1504280390367-361c6d9f38f4?w=400&q=80",
+			},
+			{
+				id: 20,
+				productId: 602,
+				name: "캠핑용 폴딩 체어 세트 (2P)",
+				price: 29800,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1523906834658-6e24ef2386f9?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 141,
+		ownerName: "서준혁",
+		name: "1박 2일 솔로 캠핑 장비",
+		type: "personal",
+		category: "camping",
+		likeCount: 267,
+		items: [
+			{
+				id: 91,
+				productId: 4001,
+				name: "프리미엄 캠핑 화로대",
+				price: 35900,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1596263576925-d90d63691097?w=400&q=80",
+			},
+			{
+				id: 92,
+				productId: 4002,
+				name: "원터치 팝업 텐트 3-4인용",
+				price: 49900,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1504280390367-361c6d9f38f4?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 142,
+		ownerName: "나영희 팀",
+		name: "가족 글램핑 준비",
+		type: "shared",
+		category: "camping",
+		likeCount: 231,
+		items: [
+			{
+				id: 93,
+				productId: 4003,
+				name: "대용량 아이스박스 30L",
+				price: 45000,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1533900298318-6b8da08a523e?w=400&q=80",
+			},
+			{
+				id: 94,
+				productId: 4004,
+				name: "캠핑용 폴딩 체어 세트 (2P)",
+				price: 29800,
+				quantity: 2,
+				thumbnail:
+					"https://images.unsplash.com/photo-1523906834658-6e24ef2386f9?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 143,
+		ownerName: "문재현",
+		name: "여름 워터 캠핑 세트",
+		type: "personal",
+		category: "camping",
+		likeCount: 179,
+		items: [
+			{
+				id: 95,
+				productId: 4005,
+				name: "대용량 아이스박스 30L",
+				price: 45000,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1533900298318-6b8da08a523e?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 144,
+		ownerName: "유진아 팀",
+		name: "대학 동기 MT 캠핑",
+		type: "shared",
+		category: "camping",
+		likeCount: 155,
+		items: [
+			{
+				id: 96,
+				productId: 4006,
+				name: "프리미엄 캠핑 화로대",
+				price: 35900,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1596263576925-d90d63691097?w=400&q=80",
+			},
+			{
+				id: 97,
+				productId: 4007,
+				name: "원터치 팝업 텐트 3-4인용",
+				price: 49900,
+				quantity: 2,
+				thumbnail:
+					"https://images.unsplash.com/photo-1504280390367-361c6d9f38f4?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 145,
+		ownerName: "김태양",
+		name: "백패킹 경량 장비",
+		type: "personal",
+		category: "camping",
+		likeCount: 133,
+		items: [
+			{
+				id: 98,
+				productId: 4008,
+				name: "캠핑용 폴딩 체어 세트 (2P)",
+				price: 29800,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1523906834658-6e24ef2386f9?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 146,
+		ownerName: "박채린 팀",
+		name: "회사 단체 캠핑 용품",
+		type: "shared",
+		category: "camping",
+		likeCount: 112,
+		items: [
+			{
+				id: 99,
+				productId: 4009,
+				name: "대용량 아이스박스 30L",
+				price: 45000,
+				quantity: 2,
+				thumbnail:
+					"https://images.unsplash.com/photo-1533900298318-6b8da08a523e?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 147,
+		ownerName: "장민수",
+		name: "오토캠핑 필수 장비",
+		type: "personal",
+		category: "camping",
+		likeCount: 89,
+		items: [
+			{
+				id: 100,
+				productId: 4010,
+				name: "프리미엄 캠핑 화로대",
+				price: 35900,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1596263576925-d90d63691097?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 148,
+		ownerName: "홍지수",
+		name: "감성 캠핑 소품",
+		type: "personal",
+		category: "camping",
+		likeCount: 74,
+		items: [
+			{
+				id: 101,
+				productId: 4011,
+				name: "원터치 팝업 텐트 3-4인용",
+				price: 49900,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1504280390367-361c6d9f38f4?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 149,
+		ownerName: "이준호 팀",
+		name: "낚시 겸 캠핑 장비",
+		type: "shared",
+		category: "camping",
+		likeCount: 62,
+		items: [
+			{
+				id: 102,
+				productId: 4012,
+				name: "캠핑용 폴딩 체어 세트 (2P)",
+				price: 29800,
+				quantity: 3,
+				thumbnail:
+					"https://images.unsplash.com/photo-1523906834658-6e24ef2386f9?w=400&q=80",
+			},
+		],
+	},
+
+	// ── 추가 생활용품 (living) ──────────────────────
+	{
+		id: 201,
+		ownerName: "김하린",
+		name: "미니멀 세탁 용품",
+		type: "personal" as const,
+		category: "living" as const,
+		likeCount: 68,
+		items: [
+			{
+				id: 201,
+				productId: 5001,
+				name: "섬유유연제 1L",
+				price: 5900,
+				quantity: 2,
+				thumbnail:
+					"https://images.unsplash.com/photo-1585421514284-efb74c2b69ba?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 202,
+		ownerName: "이태민 팀",
+		name: "사무실 청소 용품",
+		type: "shared" as const,
+		category: "living" as const,
+		likeCount: 59,
+		items: [
+			{
+				id: 202,
+				productId: 5002,
+				name: "물걸레 청소포 30매",
+				price: 4900,
+				quantity: 5,
+				thumbnail:
+					"https://images.unsplash.com/photo-1585421514284-efb74c2b69ba?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 203,
+		ownerName: "박서진",
+		name: "아기 목욕 용품",
+		type: "personal" as const,
+		category: "living" as const,
+		likeCount: 52,
+		items: [
+			{
+				id: 203,
+				productId: 5003,
+				name: "베이비 바디워시 300ml",
+				price: 12900,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1556228578-0d85b1a4d571?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 204,
+		ownerName: "최민호",
+		name: "겨울철 가습 용품",
+		type: "personal" as const,
+		category: "living" as const,
+		likeCount: 46,
+		items: [
+			{
+				id: 204,
+				productId: 5004,
+				name: "초음파 가습기",
+				price: 29900,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 205,
+		ownerName: "송유진 팀",
+		name: "학교 기숙사 공용 세제",
+		type: "shared" as const,
+		category: "living" as const,
+		likeCount: 41,
+		items: [
+			{
+				id: 205,
+				productId: 5005,
+				name: "주방세제 500ml",
+				price: 3200,
+				quantity: 8,
+				thumbnail:
+					"https://images.unsplash.com/photo-1585421514284-efb74c2b69ba?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 206,
+		ownerName: "장유나",
+		name: "욕실 리모델링 소품",
+		type: "personal" as const,
+		category: "living" as const,
+		likeCount: 37,
+		items: [
+			{
+				id: 206,
+				productId: 5006,
+				name: "스테인리스 수건걸이",
+				price: 8900,
+				quantity: 2,
+				thumbnail:
+					"https://images.unsplash.com/photo-1584622781564-1d987f7333c1?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 207,
+		ownerName: "한지우",
+		name: "향기 디퓨저 세트",
+		type: "personal" as const,
+		category: "living" as const,
+		likeCount: 33,
+		items: [
+			{
+				id: 207,
+				productId: 5007,
+				name: "라벤더 디퓨저 200ml",
+				price: 18000,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 208,
+		ownerName: "오현서 팀",
+		name: "공유 오피스 생필품",
+		type: "shared" as const,
+		category: "living" as const,
+		likeCount: 29,
+		items: [
+			{
+				id: 208,
+				productId: 5008,
+				name: "핸드워시 250ml",
+				price: 3500,
+				quantity: 10,
+				thumbnail:
+					"https://images.unsplash.com/photo-1556228578-0d85b1a4d571?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 209,
+		ownerName: "윤서윤",
+		name: "다용도 수납 정리",
+		type: "personal" as const,
+		category: "living" as const,
+		likeCount: 25,
+		items: [
+			{
+				id: 209,
+				productId: 5009,
+				name: "투명 수납함 3단",
+				price: 15900,
+				quantity: 2,
+				thumbnail:
+					"https://images.unsplash.com/photo-1558618666-fcd25c85cd64?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 210,
+		ownerName: "강태현",
+		name: "혼자사는 남자 필수템",
+		type: "personal" as const,
+		category: "living" as const,
+		likeCount: 22,
+		items: [
+			{
+				id: 210,
+				productId: 5010,
+				name: "만능 세탁 세제 2L",
+				price: 9900,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1585421514284-efb74c2b69ba?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 211,
+		ownerName: "문소율",
+		name: "비건 스킨케어",
+		type: "personal" as const,
+		category: "living" as const,
+		likeCount: 19,
+		items: [
+			{
+				id: 211,
+				productId: 5011,
+				name: "비건 클렌징 폼 150ml",
+				price: 16900,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1611930022073-b7a4ba5fcccd?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 212,
+		ownerName: "서하늘 팀",
+		name: "동호회 피크닉 용품",
+		type: "shared" as const,
+		category: "living" as const,
+		likeCount: 16,
+		items: [
+			{
+				id: 212,
+				productId: 5012,
+				name: "돗자리 대형",
+				price: 12000,
+				quantity: 3,
+				thumbnail:
+					"https://images.unsplash.com/photo-1558618666-fcd25c85cd64?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 213,
+		ownerName: "이나연",
+		name: "헤어케어 루틴",
+		type: "personal" as const,
+		category: "living" as const,
+		likeCount: 13,
+		items: [
+			{
+				id: 213,
+				productId: 5013,
+				name: "두피 샴푸 500ml",
+				price: 14900,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1556228578-0d85b1a4d571?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 214,
+		ownerName: "김도원",
+		name: "자취 첫 살림살이",
+		type: "personal" as const,
+		category: "living" as const,
+		likeCount: 10,
+		items: [
+			{
+				id: 214,
+				productId: 5014,
+				name: "빨래건조대 접이식",
+				price: 22000,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1558618666-fcd25c85cd64?w=400&q=80",
+			},
+		],
+	},
+
+	// ── 추가 식재료 (ingredients) ───────────────────
+	{
+		id: 301,
+		ownerName: "정하율",
+		name: "간편 아침 세트",
+		type: "personal" as const,
+		category: "ingredients" as const,
+		likeCount: 63,
+		items: [
+			{
+				id: 301,
+				productId: 6001,
+				name: "그래놀라 500g",
+				price: 7900,
+				quantity: 2,
+				thumbnail:
+					"https://images.unsplash.com/photo-1536304929831-ee1ca9d44906?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 302,
+		ownerName: "홍서현 팀",
+		name: "동네 반찬가게 공동구매",
+		type: "shared" as const,
+		category: "ingredients" as const,
+		likeCount: 57,
+		items: [
+			{
+				id: 302,
+				productId: 6002,
+				name: "갈비찜 밀키트 600g",
+				price: 15900,
+				quantity: 4,
+				thumbnail:
+					"https://images.unsplash.com/photo-1763140446057-9becaa30b868?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 303,
+		ownerName: "류지훈",
+		name: "홈파티 디저트 재료",
+		type: "personal" as const,
+		category: "ingredients" as const,
+		likeCount: 51,
+		items: [
+			{
+				id: 303,
+				productId: 6003,
+				name: "생크림 500ml",
+				price: 4200,
+				quantity: 3,
+				thumbnail:
+					"https://images.unsplash.com/photo-1621996346565-e3dbc646d9a9?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 304,
+		ownerName: "안세영",
+		name: "여름 음료 만들기",
+		type: "personal" as const,
+		category: "ingredients" as const,
+		likeCount: 45,
+		items: [
+			{
+				id: 304,
+				productId: 6004,
+				name: "레몬 1kg",
+				price: 6900,
+				quantity: 2,
+				thumbnail:
+					"https://images.unsplash.com/photo-1534483509719-3feaee7c30da?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 305,
+		ownerName: "백준혁 팀",
+		name: "소풍 간식 공동구매",
+		type: "shared" as const,
+		category: "ingredients" as const,
+		likeCount: 40,
+		items: [
+			{
+				id: 305,
+				productId: 6005,
+				name: "삼각김밥 10입",
+				price: 9900,
+				quantity: 6,
+				thumbnail:
+					"https://images.unsplash.com/photo-1536304929831-ee1ca9d44906?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 306,
+		ownerName: "김나윤",
+		name: "건강 주스 재료",
+		type: "personal" as const,
+		category: "ingredients" as const,
+		likeCount: 36,
+		items: [
+			{
+				id: 306,
+				productId: 6006,
+				name: "케일 200g",
+				price: 3500,
+				quantity: 4,
+				thumbnail:
+					"https://images.unsplash.com/photo-1557142046-c704a3adf364?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 307,
+		ownerName: "이승우",
+		name: "김치찌개 재료 세트",
+		type: "personal" as const,
+		category: "ingredients" as const,
+		likeCount: 32,
+		items: [
+			{
+				id: 307,
+				productId: 6007,
+				name: "돼지 앞다리살 500g",
+				price: 8900,
+				quantity: 2,
+				thumbnail:
+					"https://images.unsplash.com/photo-1763140446057-9becaa30b868?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 308,
+		ownerName: "박채원 팀",
+		name: "연구실 커피 원두 공구",
+		type: "shared" as const,
+		category: "ingredients" as const,
+		likeCount: 28,
+		items: [
+			{
+				id: 308,
+				productId: 6008,
+				name: "원두 커피 1kg",
+				price: 19900,
+				quantity: 3,
+				thumbnail:
+					"https://images.unsplash.com/photo-1495474472287-4d71bcdd2085?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 309,
+		ownerName: "우지민",
+		name: "과일 정기배송 리스트",
+		type: "personal" as const,
+		category: "ingredients" as const,
+		likeCount: 24,
+		items: [
+			{
+				id: 309,
+				productId: 6009,
+				name: "사과 5입",
+				price: 8900,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1534483509719-3feaee7c30da?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 310,
+		ownerName: "신태양",
+		name: "매운맛 라면 도전",
+		type: "personal" as const,
+		category: "ingredients" as const,
+		likeCount: 21,
+		items: [
+			{
+				id: 310,
+				productId: 6010,
+				name: "불닭볶음면 5입",
+				price: 3900,
+				quantity: 3,
+				thumbnail:
+					"https://images.unsplash.com/photo-1612929633738-8fe44f7ec841?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 311,
+		ownerName: "조아린 팀",
+		name: "회식 재료 공동구매",
+		type: "shared" as const,
+		category: "ingredients" as const,
+		likeCount: 18,
+		items: [
+			{
+				id: 311,
+				productId: 6011,
+				name: "삼겹살 600g",
+				price: 14900,
+				quantity: 5,
+				thumbnail:
+					"https://images.unsplash.com/photo-1763140446057-9becaa30b868?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 312,
+		ownerName: "한예은",
+		name: "베이킹 입문 재료",
+		type: "personal" as const,
+		category: "ingredients" as const,
+		likeCount: 15,
+		items: [
+			{
+				id: 312,
+				productId: 6012,
+				name: "강력분 밀가루 1kg",
+				price: 3200,
+				quantity: 2,
+				thumbnail:
+					"https://images.unsplash.com/photo-1621996346565-e3dbc646d9a9?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 313,
+		ownerName: "문지호",
+		name: "혼밥 냉동식품 세트",
+		type: "personal" as const,
+		category: "ingredients" as const,
+		likeCount: 12,
+		items: [
+			{
+				id: 313,
+				productId: 6013,
+				name: "냉동 만두 700g",
 				price: 6900,
 				quantity: 3,
 				thumbnail:
-					"https://images.unsplash.com/photo-1582722872445-44dc5f7e3c8f?w=400&q=80",
+					"https://images.unsplash.com/photo-1565680018434-b513d5e5fd47?w=400&q=80",
 			},
+		],
+	},
+	{
+		id: 314,
+		ownerName: "강소민",
+		name: "비건 식재료 장보기",
+		type: "personal" as const,
+		category: "ingredients" as const,
+		likeCount: 9,
+		items: [
 			{
-				id: 30,
-				productId: 1002,
-				name: "로제파스타 소스 200g",
+				id: 314,
+				productId: 6014,
+				name: "유기농 두유 1L",
 				price: 4500,
+				quantity: 4,
+				thumbnail:
+					"https://images.unsplash.com/photo-1557142046-c704a3adf364?w=400&q=80",
+			},
+		],
+	},
+
+	// ── 추가 사무용품 (office) ──────────────────────
+	{
+		id: 401,
+		ownerName: "이다은",
+		name: "시험 준비 문구",
+		type: "personal" as const,
+		category: "office" as const,
+		likeCount: 58,
+		items: [
+			{
+				id: 401,
+				productId: 7001,
+				name: "노크식 볼펜 5입",
+				price: 2900,
+				quantity: 4,
+				thumbnail:
+					"https://images.unsplash.com/photo-1585336261022-680e295ce3fe?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 402,
+		ownerName: "김준영 팀",
+		name: "팀 회의실 비품",
+		type: "shared" as const,
+		category: "office" as const,
+		likeCount: 53,
+		items: [
+			{
+				id: 402,
+				productId: 7002,
+				name: "화이트보드 마커 6색",
+				price: 5900,
 				quantity: 5,
 				thumbnail:
-					"https://images.unsplash.com/photo-1621996346565-e3dbc646d9a9?w=400&q=80",
+					"https://images.unsplash.com/photo-1513542789411-b6a5d4f31634?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 403,
+		ownerName: "서민아",
+		name: "다이어리 꾸미기",
+		type: "personal" as const,
+		category: "office" as const,
+		likeCount: 47,
+		items: [
+			{
+				id: 403,
+				productId: 7003,
+				name: "마스킹 테이프 10입",
+				price: 8900,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1586380951230-e6703d9f6833?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 404,
+		ownerName: "박시율",
+		name: "공시생 필수 세트",
+		type: "personal" as const,
+		category: "office" as const,
+		likeCount: 42,
+		items: [
+			{
+				id: 404,
+				productId: 7004,
+				name: "뾰족 샤프 0.5mm",
+				price: 3500,
+				quantity: 3,
+				thumbnail:
+					"https://images.unsplash.com/photo-1585336261022-680e295ce3fe?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 405,
+		ownerName: "정하은 팀",
+		name: "강의실 공용 필기구",
+		type: "shared" as const,
+		category: "office" as const,
+		likeCount: 38,
+		items: [
+			{
+				id: 405,
+				productId: 7005,
+				name: "보드 마카 세트",
+				price: 6900,
+				quantity: 6,
+				thumbnail:
+					"https://images.unsplash.com/photo-1513542789411-b6a5d4f31634?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 406,
+		ownerName: "최유빈",
+		name: "그래픽 작업 도구",
+		type: "personal" as const,
+		category: "office" as const,
+		likeCount: 34,
+		items: [
+			{
+				id: 406,
+				productId: 7006,
+				name: "타블렛 보호필름",
+				price: 12900,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1527864550417-7fd91fc51a46?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 407,
+		ownerName: "한도진",
+		name: "미팅 준비 세트",
+		type: "personal" as const,
+		category: "office" as const,
+		likeCount: 30,
+		items: [
+			{
+				id: 407,
+				productId: 7007,
+				name: "명함 지갑 가죽",
+				price: 15000,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1583485088034-697b5bc54ccd?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 408,
+		ownerName: "권서아 팀",
+		name: "인턴 팀 사무용품",
+		type: "shared" as const,
+		category: "office" as const,
+		likeCount: 26,
+		items: [
+			{
+				id: 408,
+				productId: 7008,
+				name: "클립보드 A4",
+				price: 4500,
+				quantity: 8,
+				thumbnail:
+					"https://images.unsplash.com/photo-1586281380349-632531db7ed4?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 409,
+		ownerName: "임지아",
+		name: "노트 수집가 세트",
+		type: "personal" as const,
+		category: "office" as const,
+		likeCount: 23,
+		items: [
+			{
+				id: 409,
+				productId: 7009,
+				name: "스프링 노트 5권",
+				price: 7900,
+				quantity: 2,
+				thumbnail:
+					"https://images.unsplash.com/photo-1568702846914-96b305d2ead1?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 410,
+		ownerName: "배성민",
+		name: "책상 정리 도구",
+		type: "personal" as const,
+		category: "office" as const,
+		likeCount: 20,
+		items: [
+			{
+				id: 410,
+				productId: 7010,
+				name: "서류 트레이 3단",
+				price: 11900,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1586281380349-632531db7ed4?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 411,
+		ownerName: "신하영 팀",
+		name: "디자인팀 공용 문구",
+		type: "shared" as const,
+		category: "office" as const,
+		likeCount: 17,
+		items: [
+			{
+				id: 411,
+				productId: 7011,
+				name: "색연필 36색",
+				price: 15900,
+				quantity: 3,
+				thumbnail:
+					"https://images.unsplash.com/photo-1513542789411-b6a5d4f31634?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 412,
+		ownerName: "윤채은",
+		name: "캘리그라피 입문",
+		type: "personal" as const,
+		category: "office" as const,
+		likeCount: 14,
+		items: [
+			{
+				id: 412,
+				productId: 7012,
+				name: "딥펜 세트",
+				price: 22000,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1585336261022-680e295ce3fe?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 413,
+		ownerName: "고영준",
+		name: "코딩 데스크 셋업",
+		type: "personal" as const,
+		category: "office" as const,
+		likeCount: 11,
+		items: [
+			{
+				id: 413,
+				productId: 7013,
+				name: "노트북 거치대",
+				price: 29900,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1527864550417-7fd91fc51a46?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 414,
+		ownerName: "남지현",
+		name: "플래너 매니아",
+		type: "personal" as const,
+		category: "office" as const,
+		likeCount: 8,
+		items: [
+			{
+				id: 414,
+				productId: 7014,
+				name: "2026 위클리 플래너",
+				price: 12900,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1568702846914-96b305d2ead1?w=400&q=80",
+			},
+		],
+	},
+
+	// ── 추가 캠핑용품 (camping) ─────────────────────
+	{
+		id: 501,
+		ownerName: "김하진",
+		name: "미니멀 캠핑 장비",
+		type: "personal" as const,
+		category: "camping" as const,
+		likeCount: 56,
+		items: [
+			{
+				id: 501,
+				productId: 8001,
+				name: "미니 버너 세트",
+				price: 35000,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1596263576925-d90d63691097?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 502,
+		ownerName: "이서준 팀",
+		name: "가족 캠핑 음식 준비",
+		type: "shared" as const,
+		category: "camping" as const,
+		likeCount: 50,
+		items: [
+			{
+				id: 502,
+				productId: 8002,
+				name: "캠핑 코펠 세트",
+				price: 42000,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1596263576925-d90d63691097?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 503,
+		ownerName: "박시온",
+		name: "겨울 캠핑 방한 세트",
+		type: "personal" as const,
+		category: "camping" as const,
+		likeCount: 44,
+		items: [
+			{
+				id: 503,
+				productId: 8003,
+				name: "동계용 침낭 -10℃",
+				price: 79900,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1504280390367-361c6d9f38f4?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 504,
+		ownerName: "정민주",
+		name: "캠핑 조명 모음",
+		type: "personal" as const,
+		category: "camping" as const,
+		likeCount: 39,
+		items: [
+			{
+				id: 504,
+				productId: 8004,
+				name: "LED 캠핑 랜턴",
+				price: 25900,
+				quantity: 2,
+				thumbnail:
+					"https://images.unsplash.com/photo-1504280390367-361c6d9f38f4?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 505,
+		ownerName: "황서연 팀",
+		name: "봄 꽃놀이 캠핑",
+		type: "shared" as const,
+		category: "camping" as const,
+		likeCount: 35,
+		items: [
+			{
+				id: 505,
+				productId: 8005,
+				name: "타프 스크린 대형",
+				price: 89000,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1504280390367-361c6d9f38f4?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 506,
+		ownerName: "송지안",
+		name: "캠핑 취사 도구",
+		type: "personal" as const,
+		category: "camping" as const,
+		likeCount: 31,
+		items: [
+			{
+				id: 506,
+				productId: 8006,
+				name: "캠핑 칼세트 3P",
+				price: 18900,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1596263576925-d90d63691097?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 507,
+		ownerName: "오태성",
+		name: "차박 필수 장비",
+		type: "personal" as const,
+		category: "camping" as const,
+		likeCount: 27,
+		items: [
+			{
+				id: 507,
+				productId: 8007,
+				name: "차량용 에어매트",
+				price: 45900,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1504280390367-361c6d9f38f4?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 508,
+		ownerName: "노은서 팀",
+		name: "여름 물놀이 캠핑",
+		type: "shared" as const,
+		category: "camping" as const,
+		likeCount: 23,
+		items: [
+			{
+				id: 508,
+				productId: 8008,
+				name: "방수 돗자리 XL",
+				price: 19900,
+				quantity: 3,
+				thumbnail:
+					"https://images.unsplash.com/photo-1523906834658-6e24ef2386f9?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 509,
+		ownerName: "윤세진",
+		name: "캠핑 수납 정리함",
+		type: "personal" as const,
+		category: "camping" as const,
+		likeCount: 20,
+		items: [
+			{
+				id: 509,
+				productId: 8009,
+				name: "접이식 수납 박스 50L",
+				price: 22000,
+				quantity: 2,
+				thumbnail:
+					"https://images.unsplash.com/photo-1533900298318-6b8da08a523e?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 510,
+		ownerName: "배하은",
+		name: "글램핑 인테리어",
+		type: "personal" as const,
+		category: "camping" as const,
+		likeCount: 17,
+		items: [
+			{
+				id: 510,
+				productId: 8010,
+				name: "감성 전구 조명 5m",
+				price: 12900,
+				quantity: 2,
+				thumbnail:
+					"https://images.unsplash.com/photo-1504280390367-361c6d9f38f4?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 511,
+		ownerName: "임채준 팀",
+		name: "등산 겸 캠핑 세트",
+		type: "shared" as const,
+		category: "camping" as const,
+		likeCount: 14,
+		items: [
+			{
+				id: 511,
+				productId: 8011,
+				name: "경량 등산화",
+				price: 59900,
+				quantity: 4,
+				thumbnail:
+					"https://images.unsplash.com/photo-1523906834658-6e24ef2386f9?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 512,
+		ownerName: "강예찬",
+		name: "캠핑 커피 세트",
+		type: "personal" as const,
+		category: "camping" as const,
+		likeCount: 11,
+		items: [
+			{
+				id: 512,
+				productId: 8012,
+				name: "핸드드립 세트",
+				price: 28900,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1495474472287-4d71bcdd2085?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 513,
+		ownerName: "조서진",
+		name: "반려견 캠핑 용품",
+		type: "personal" as const,
+		category: "camping" as const,
+		likeCount: 8,
+		items: [
+			{
+				id: 513,
+				productId: 8013,
+				name: "접이식 강아지 울타리",
+				price: 35900,
+				quantity: 1,
+				thumbnail:
+					"https://images.unsplash.com/photo-1587300003388-59208cc962cb?w=400&q=80",
+			},
+		],
+	},
+	{
+		id: 514,
+		ownerName: "한승현 팀",
+		name: "겨울 캠핑 핫팩 공구",
+		type: "shared" as const,
+		category: "camping" as const,
+		likeCount: 5,
+		items: [
+			{
+				id: 514,
+				productId: 8014,
+				name: "대용량 핫팩 30입",
+				price: 9900,
+				quantity: 6,
+				thumbnail:
+					"https://images.unsplash.com/photo-1533900298318-6b8da08a523e?w=400&q=80",
 			},
 		],
 	},

--- a/src/mock/product.ts
+++ b/src/mock/product.ts
@@ -40,17 +40,15 @@ export interface Category {
 
 // 카테고리 목록
 export const categories: Category[] = [
-	{ id: "food", label: "식품 및 식자재" },
 	{ id: "living", label: "생활용품" },
-	{ id: "kitchen", label: "주방용품" },
+	{ id: "ingredients", label: "식재료" },
 	{ id: "office", label: "사무용품" },
-	{ id: "fashion", label: "패션의류/잡화" },
-	{ id: "books", label: "도서/음반/DVD" },
+	{ id: "camping", label: "캠핑용품" },
 ];
 
 // 전체 상품 데이터
 export const products: Product[] = [
-	// ── 식품 및 식자재 ──
+	// ── 식재료 ──
 	{
 		id: 1,
 		image_url:
@@ -60,7 +58,7 @@ export const products: Product[] = [
 			"피코크 브랜드의 프리미엄 한우 불고기 밀키트. 신선한 한우와 특제 양념으로 간편하게 불고기를 즐길 수 있습니다.",
 		price: 12900,
 		stock: 150,
-		category: "food",
+		category: "ingredients",
 		created_at: "2026-01-15T09:00:00",
 		updated_at: "2026-02-20T14:30:00",
 	},
@@ -73,7 +71,7 @@ export const products: Product[] = [
 			"노브랜드 국내산 신선 계란 30구. HACCP 인증 농장에서 당일 수거한 계란을 안전하게 배송합니다.",
 		price: 6900,
 		stock: 300,
-		category: "food",
+		category: "ingredients",
 		created_at: "2026-01-10T08:00:00",
 		updated_at: "2026-02-21T10:00:00",
 	},
@@ -86,7 +84,7 @@ export const products: Product[] = [
 			"풀무원 국산콩 100%로 만든 두부. 고소한 맛과 부드러운 식감이 특징입니다.",
 		price: 3480,
 		stock: 500,
-		category: "food",
+		category: "ingredients",
 		created_at: "2026-01-12T09:30:00",
 		updated_at: "2026-02-19T11:00:00",
 	},
@@ -99,7 +97,7 @@ export const products: Product[] = [
 			"CJ제일제당 햇반. 100% 국내산 쌀로 지은 즉석밥으로 전자레인지 2분이면 갓 지은 밥맛을 즐길 수 있습니다.",
 		price: 14900,
 		stock: 800,
-		category: "food",
+		category: "ingredients",
 		created_at: "2026-01-05T07:00:00",
 		updated_at: "2026-02-20T09:00:00",
 	},
@@ -112,7 +110,7 @@ export const products: Product[] = [
 			"동원 참치. 깨끗한 바다에서 잡은 참치를 신선하게 가공한 프리미엄 참치캔입니다.",
 		price: 8900,
 		stock: 600,
-		category: "food",
+		category: "ingredients",
 		created_at: "2026-01-08T10:00:00",
 		updated_at: "2026-02-18T15:00:00",
 	},
@@ -125,7 +123,7 @@ export const products: Product[] = [
 			"오뚜기 진라면 순한맛. 깊고 진한 국물 맛에 순한 매운맛을 더해 누구나 즐길 수 있는 라면입니다.",
 		price: 3200,
 		stock: 1200,
-		category: "food",
+		category: "ingredients",
 		created_at: "2026-01-03T08:00:00",
 		updated_at: "2026-02-21T08:00:00",
 	},
@@ -138,7 +136,7 @@ export const products: Product[] = [
 			"노브랜드 냉동 새우. 급속 냉동으로 신선함을 그대로 유지한 대하급 새우입니다.",
 		price: 9900,
 		stock: 200,
-		category: "food",
+		category: "ingredients",
 		created_at: "2026-01-14T11:00:00",
 		updated_at: "2026-02-19T16:00:00",
 	},
@@ -151,7 +149,7 @@ export const products: Product[] = [
 			"피코크 로제파스타 소스. 토마토와 크림의 조화로운 맛으로 집에서도 레스토랑급 파스타를 즐길 수 있습니다.",
 		price: 4500,
 		stock: 400,
-		category: "food",
+		category: "ingredients",
 		created_at: "2026-01-20T09:00:00",
 		updated_at: "2026-02-20T12:00:00",
 	},
@@ -262,112 +260,6 @@ export const products: Product[] = [
 		updated_at: "2026-02-20T10:00:00",
 	},
 
-	// ── 주방용품 ──
-	{
-		id: 17,
-		image_url:
-			"https://images.unsplash.com/photo-1556909114-f6e7ad7d3136?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400",
-		name: "클리어 밀폐용기 4P세트",
-		description:
-			"락앤락 클리어 밀폐용기 세트. 강력한 밀폐력으로 식재료를 신선하게 보관할 수 있습니다.",
-		price: 19900,
-		stock: 180,
-		category: "kitchen",
-		created_at: "2026-01-10T08:00:00",
-		updated_at: "2026-02-19T13:00:00",
-	},
-	{
-		id: 18,
-		image_url:
-			"https://images.unsplash.com/photo-1585664811087-47f65abbad64?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400",
-		name: "IH 프라이팬 28cm",
-		description:
-			"해피콜 IH 프라이팬. 인덕션 호환 가능한 논스틱 코팅 프라이팬으로 모든 열원에서 사용 가능합니다.",
-		price: 34900,
-		stock: 120,
-		category: "kitchen",
-		created_at: "2026-01-08T09:00:00",
-		updated_at: "2026-02-20T16:00:00",
-	},
-	{
-		id: 19,
-		image_url:
-			"https://images.unsplash.com/photo-1584568694244-14fbdf83bd30?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400",
-		name: "식기건조대 스텐 대형",
-		description:
-			"노브랜드 스테인리스 식기건조대. 녹슬지 않는 스텐 소재로 위생적으로 식기를 건조할 수 있습니다.",
-		price: 15900,
-		stock: 90,
-		category: "kitchen",
-		created_at: "2026-01-15T10:00:00",
-		updated_at: "2026-02-18T14:00:00",
-	},
-	{
-		id: 20,
-		image_url:
-			"https://images.unsplash.com/photo-1594226801341-41427b4e5c22?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400",
-		name: "도마 항균 양면 대형",
-		description:
-			"키친아트 항균 양면 도마. 고밀도 소재로 칼 자국이 잘 생기지 않으며 항균 처리되어 위생적입니다.",
-		price: 12900,
-		stock: 200,
-		category: "kitchen",
-		created_at: "2026-01-12T08:00:00",
-		updated_at: "2026-02-21T10:00:00",
-	},
-	{
-		id: 21,
-		image_url:
-			"https://images.unsplash.com/photo-1544233726-9f1d2b27be8b?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400",
-		name: "전기압력밥솥 6인용",
-		description:
-			"쿠쿠 전기압력밥솥. 다양한 취사 모드와 간편한 세척으로 매일 맛있는 밥을 지을 수 있습니다.",
-		price: 89000,
-		stock: 50,
-		category: "kitchen",
-		created_at: "2026-01-02T07:00:00",
-		updated_at: "2026-02-20T12:00:00",
-	},
-	{
-		id: 22,
-		image_url:
-			"https://images.unsplash.com/photo-1593618998160-e34014e67546?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400",
-		name: "칼갈이 세라믹 2단",
-		description:
-			"노브랜드 세라믹 칼갈이. 2단계 연마 시스템으로 무디어진 칼날을 간편하게 복원시킵니다.",
-		price: 8900,
-		stock: 300,
-		category: "kitchen",
-		created_at: "2026-01-17T09:00:00",
-		updated_at: "2026-02-19T15:00:00",
-	},
-	{
-		id: 23,
-		image_url:
-			"https://images.unsplash.com/photo-1556911220-e15b29be8c4f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400",
-		name: "실리콘 주방장갑 2P",
-		description:
-			"실리쿡 실리콘 주방장갑. 내열 250℃까지 견디며 미끄럼 방지 처리로 안전하게 사용할 수 있습니다.",
-		price: 5900,
-		stock: 350,
-		category: "kitchen",
-		created_at: "2026-01-19T10:00:00",
-		updated_at: "2026-02-21T09:00:00",
-	},
-	{
-		id: 24,
-		image_url:
-			"https://images.unsplash.com/photo-1530982011887-3cc11cc85693?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400",
-		name: "유리 계량컵 500ml",
-		description:
-			"테팔 유리 계량컵. 내열 유리 소재로 전자레인지 사용 가능하며 눈금이 선명합니다.",
-		price: 7900,
-		stock: 280,
-		category: "kitchen",
-		created_at: "2026-01-21T08:00:00",
-		updated_at: "2026-02-20T14:00:00",
-	},
-
 	// ── 사무용품 ──
 	{
 		id: 25,
@@ -474,215 +366,58 @@ export const products: Product[] = [
 		updated_at: "2026-02-19T16:00:00",
 	},
 
-	// ── 패션의류/잡화 ──
+	// ── 캠핑용품 ──
 	{
-		id: 33,
+		id: 49,
 		image_url:
-			"https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400",
-		name: "기본 코튼 티셔츠 (화이트)",
+			"https://images.unsplash.com/photo-1504280390367-361c6d9f38f4?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400",
+		name: "원터치 팝업 텐트 3-4인용",
 		description:
-			"노브랜드 기본 코튼 티셔츠. 100% 면 소재로 부드러운 착용감과 다양한 스타일링이 가능합니다.",
-		price: 9900,
-		stock: 500,
-		category: "fashion",
-		created_at: "2026-01-08T08:00:00",
-		updated_at: "2026-02-20T09:00:00",
+			"노브랜드 원터치 텐트. 3초 만에 펼쳐지는 간편한 설치로 초보 캠퍼에게 추천하는 제품입니다.",
+		price: 49900,
+		stock: 100,
+		category: "camping",
+		created_at: "2026-01-20T08:00:00",
+		updated_at: "2026-02-20T15:00:00",
 	},
 	{
-		id: 34,
+		id: 50,
 		image_url:
-			"https://images.unsplash.com/photo-1542272604-787c3835535d?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400",
-		name: "슬림핏 청바지 32인치",
+			"https://images.unsplash.com/photo-1523906834658-6e24ef2386f9?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400",
+		name: "캠핑용 폴딩 체어 세트 (2P)",
 		description:
-			"스파오 슬림핏 청바지. 신축성 있는 데님 소재로 편안한 착용감과 깔끔한 실루엣을 제공합니다.",
-		price: 29900,
-		stock: 220,
-		category: "fashion",
-		created_at: "2026-01-10T09:00:00",
+			"노브랜드 접이식 캠핑 의자. 튼튼한 프레임과 내구성이 뛰어난 옥스퍼드 원단으로 편안한 휴식을 제공합니다.",
+		price: 29800,
+		stock: 150,
+		category: "camping",
+		created_at: "2026-01-22T09:00:00",
 		updated_at: "2026-02-19T11:00:00",
 	},
 	{
-		id: 35,
+		id: 51,
 		image_url:
-			"https://images.unsplash.com/photo-1460353581641-37baddab0fa2?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400",
-		name: "클래식 스니커즈 270mm",
+			"https://images.unsplash.com/photo-1596263576925-d90d63691097?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400",
+		name: "프리미엄 캠핑 화로대",
 		description:
-			"노브랜드 클래식 스니커즈. 심플한 디자인으로 어떤 코디에나 어울리는 데일리 슈즈입니다.",
-		price: 24900,
-		stock: 180,
-		category: "fashion",
-		created_at: "2026-01-12T10:00:00",
+			"튼튼한 스테인리스 소재의 캠핑 화로대. 컴팩트한 사이즈로 수납과 이동이 편리합니다.",
+		price: 35900,
+		stock: 80,
+		category: "camping",
+		created_at: "2026-01-25T10:00:00",
 		updated_at: "2026-02-21T13:00:00",
 	},
 	{
-		id: 36,
+		id: 52,
 		image_url:
-			"https://images.unsplash.com/photo-1588850561407-ed78c334e67a?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400",
-		name: "야구모자 베이지",
+			"https://images.unsplash.com/photo-1533900298318-6b8da08a523e?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400",
+		name: "대용량 아이스박스 30L",
 		description:
-			"내셔널지오그래픽 야구모자. 코튼 소재의 편안한 착용감과 브랜드 로고 자수가 포인트입니다.",
-		price: 19900,
-		stock: 300,
-		category: "fashion",
-		created_at: "2026-01-15T08:00:00",
-		updated_at: "2026-02-20T14:00:00",
-	},
-	{
-		id: 37,
-		image_url:
-			"https://images.unsplash.com/photo-1591561954557-26941169b49e?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400",
-		name: "캔버스 토트백 대형",
-		description:
-			"폴로 캔버스 토트백. 넉넉한 수납공간과 견고한 캔버스 소재로 데일리 백으로 활용 가능합니다.",
-		price: 34900,
-		stock: 130,
-		category: "fashion",
-		created_at: "2026-01-18T09:00:00",
-		updated_at: "2026-02-19T15:00:00",
-	},
-	{
-		id: 38,
-		image_url:
-			"https://images.unsplash.com/photo-1586350977771-b3b0abd50c82?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400",
-		name: "양말 5켤레 세트",
-		description:
-			"노브랜드 양말 세트. 코튼 혼방 소재로 통기성이 좋으며 데일리용으로 최적화된 기본 양말입니다.",
-		price: 7900,
-		stock: 600,
-		category: "fashion",
-		created_at: "2026-01-20T10:00:00",
-		updated_at: "2026-02-20T12:00:00",
-	},
-	{
-		id: 39,
-		image_url:
-			"https://images.unsplash.com/photo-1511499767150-a48a237f0083?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400",
-		name: "선글라스 UV400",
-		description:
-			"썬스톤 선글라스. UV400 자외선 차단으로 눈을 보호하며 스타일리시한 디자인이 특징입니다.",
-		price: 14900,
-		stock: 250,
-		category: "fashion",
-		created_at: "2026-01-22T08:00:00",
-		updated_at: "2026-02-21T10:00:00",
-	},
-	{
-		id: 40,
-		image_url:
-			"https://images.unsplash.com/photo-1515562141589-67f0d569b6c0?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400",
-		name: "실버 팔찌 체인형",
-		description:
-			"반클리프 실버 팔찌. 925 스털링 실버 소재로 고급스러운 광택과 심플한 체인 디자인이 매력적입니다.",
-		price: 49900,
-		stock: 80,
-		category: "fashion",
-		created_at: "2026-01-25T09:00:00",
-		updated_at: "2026-02-20T16:00:00",
-	},
-
-	// ── 도서/음반/DVD ──
-	{
-		id: 41,
-		image_url:
-			"https://images.unsplash.com/photo-1544947950-fa07a98d237f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400",
-		name: "원씽 (게리 켈러)",
-		description:
-			"위즈덤하우스 출판. 성공한 사람들의 단 하나의 비밀을 밝히는 자기계발 베스트셀러입니다.",
-		price: 16800,
-		stock: 400,
-		category: "books",
-		created_at: "2026-01-03T07:00:00",
-		updated_at: "2026-02-18T09:00:00",
-	},
-	{
-		id: 42,
-		image_url:
-			"https://images.unsplash.com/photo-1532012197267-da84d127e765?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400",
-		name: "모던 리액트 Deep Dive",
-		description:
-			"한빛미디어 출판. React의 핵심 개념부터 고급 패턴까지 깊이 있게 다루는 기술 서적입니다.",
+			"강력한 보냉 성능을 자랑하는 아이스박스. 여름철 캠핑 및 야외 활동 시 식재료를 신선하게 보관합니다.",
 		price: 45000,
-		stock: 150,
-		category: "books",
-		created_at: "2026-01-06T08:00:00",
-		updated_at: "2026-02-21T11:00:00",
-	},
-	{
-		id: 43,
-		image_url:
-			"https://images.unsplash.com/photo-1614613535308-eb5fbd3d2c17?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400",
-		name: "aespa - Armageddon (정규 1집)",
-		description:
-			"SM엔터테인먼트. aespa의 첫 정규 앨범으로 미래적 세계관과 강렬한 퍼포먼스가 담겨 있습니다.",
-		price: 18900,
-		stock: 350,
-		category: "books",
-		created_at: "2026-01-10T09:00:00",
-		updated_at: "2026-02-20T13:00:00",
-	},
-	{
-		id: 44,
-		image_url:
-			"https://images.unsplash.com/photo-1511379938547-c1f69419868d?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400",
-		name: "BTS - Proof (앤솔로지 앨범)",
-		description: "유니버설뮤직. BTS의 9년 활동을 총망라한 앤솔로지 앨범입니다.",
-		price: 24900,
-		stock: 200,
-		category: "books",
-		created_at: "2026-01-08T10:00:00",
-		updated_at: "2026-02-19T14:00:00",
-	},
-	{
-		id: 45,
-		image_url:
-			"https://images.unsplash.com/photo-1632501641765-e568d28b0015?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400",
-		name: "보드게임 - 스플렌더",
-		description:
-			"롤링다이스. 전략적 보석 수집 보드게임으로 2-4인 플레이 가능, 30분 내외 플레이 타임입니다.",
-		price: 39900,
-		stock: 100,
-		category: "books",
-		created_at: "2026-01-14T11:00:00",
-		updated_at: "2026-02-20T10:00:00",
-	},
-	{
-		id: 46,
-		image_url:
-			"https://images.unsplash.com/photo-1543002588-bfa74002ed7e?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400",
-		name: "혼자 공부하는 파이썬 (2판)",
-		description:
-			"길벗 출판. 프로그래밍 입문자를 위한 파이썬 학습서로 실습 중심의 친절한 설명이 특징입니다.",
-		price: 22000,
-		stock: 280,
-		category: "books",
-		created_at: "2026-01-16T09:00:00",
-		updated_at: "2026-02-21T12:00:00",
-	},
-	{
-		id: 47,
-		image_url:
-			"https://images.unsplash.com/photo-1478720568477-152d9b164e26?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400",
-		name: "인터스텔라 4K UHD 블루레이",
-		description:
-			"워너브라더스. 크리스토퍼 놀란 감독의 명작 SF 영화를 4K UHD 화질로 감상할 수 있습니다.",
-		price: 28900,
 		stock: 120,
-		category: "books",
-		created_at: "2026-01-12T10:00:00",
-		updated_at: "2026-02-19T16:00:00",
-	},
-	{
-		id: 48,
-		image_url:
-			"https://images.unsplash.com/photo-1484755560615-a4c64e778571?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400",
-		name: "Harry Styles - Harry's House",
-		description:
-			"소니뮤직. Harry Styles의 3집 앨범으로 팝과 인디 사운드가 조화를 이룬 음반입니다.",
-		price: 19900,
-		stock: 190,
-		category: "books",
-		created_at: "2026-01-20T08:00:00",
-		updated_at: "2026-02-20T15:00:00",
+		category: "camping",
+		created_at: "2026-01-28T08:00:00",
+		updated_at: "2026-02-20T14:00:00",
 	},
 ];
 
@@ -700,7 +435,7 @@ export const productDetail: ProductDetail = {
 		"최상급 1++등급 한우로 만든 부드러운 등심입니다. 적절한 마블링으로 고소하고 깊은 맛을 느낄 수 있으며, 스테이크·구이·샤브샤브 등 다양하게 활용 가능합니다.",
 	price: 45800,
 	stock: 75,
-	category: "food",
+	category: "ingredients",
 	created_at: "2026-01-02T07:00:00",
 	updated_at: "2026-02-21T18:00:00",
 

--- a/src/pages/cart/CartDetailPage.tsx
+++ b/src/pages/cart/CartDetailPage.tsx
@@ -1,22 +1,47 @@
 import { useSearchParams, useNavigate } from "react-router-dom";
 import { useState } from "react";
-import { ShoppingBag, Minus, Plus, Trash2 } from "lucide-react";
-import { personalCarts, sharedCarts, type CartItem } from "../../mock/cartData";
+import {
+	ShoppingBag,
+	Minus,
+	Plus,
+	Trash2,
+	Heart,
+	User,
+	ShoppingCart,
+} from "lucide-react";
+import {
+	personalCarts,
+	sharedCarts,
+	publicCarts,
+	type CartItem,
+} from "../../mock/cartData";
 import MemberInvite from "../../components/cart/MemberInvite";
+import { useOpenSelectCartModal } from "../../store/useCartModalStore";
 
 export default function CartDetailPage() {
 	const [searchParams] = useSearchParams();
 	const navigate = useNavigate();
+	const openSelectCartModal = useOpenSelectCartModal();
 
 	const cartId = Number(searchParams.get("id"));
 	const cartType = searchParams.get("type") as "personal" | "shared" | null;
+	const source = searchParams.get("source"); // "public" 이면 publicCarts에서 조회
+	const isPublic = source === "public";
 
-	// 해당 장바구니 찾기
-	const allCarts = [
-		...personalCarts.map((c) => ({ ...c, type: "personal" as const })),
-		...sharedCarts.map((c) => ({ ...c, type: "shared" as const })),
-	];
-	const cart = allCarts.find((c) => c.id === cartId && c.type === cartType);
+	// 해당 장바구니 찾기 (source에 따라 데이터 소스 분기)
+	const cart = (() => {
+		if (isPublic) {
+			const found = publicCarts.find((c) => c.id === cartId);
+			if (!found) return undefined;
+			// PublicCart를 CartDetailPage 내부 형식으로 변환
+			return { ...found, type: found.type as "personal" | "shared" };
+		}
+		const allCarts = [
+			...personalCarts.map((c) => ({ ...c, type: "personal" as const })),
+			...sharedCarts.map((c) => ({ ...c, type: "shared" as const })),
+		];
+		return allCarts.find((c) => c.id === cartId && c.type === cartType);
+	})();
 
 	// 로컬 상품 목록 상태 (수량 변경 및 삭제용)
 	const [items, setItems] = useState<CartItem[]>(cart?.items ?? []);
@@ -97,7 +122,7 @@ export default function CartDetailPage() {
 		<div className="bg-[white]">
 			{/* 페이지 헤더 */}
 			<div className="bg-white border-b border-[white]">
-				<div className="max-w-7xl mx-auto px-6 pt-8 pb-5 flex items-center gap-4">
+				<div className="max-w-7xl mx-auto px-6 pt-8 pb-5 flex items-center justify-between gap-4">
 					<div className="flex items-center gap-2 pl-6">
 						<h1 className="text-xl font-semibold text-gray-900">
 							{cart?.name ?? "장바구니"}
@@ -108,6 +133,24 @@ export default function CartDetailPage() {
 							</span>
 						)}
 					</div>
+					{/* 공개 장바구니: 소유자 + 읽기 전용 안내 */}
+					{isPublic && cart && "ownerName" in cart && (
+						<div className="flex items-center gap-3 pr-6">
+							<span className="flex items-center gap-1 text-sm text-gray-500">
+								<User className="w-3.5 h-3.5" />
+								{(cart as { ownerName: string }).ownerName}
+							</span>
+							{"likeCount" in cart && (
+								<span className="flex items-center gap-1 text-sm text-[#C8A97A]">
+									<Heart className="w-3.5 h-3.5 fill-[#C8A97A]" />
+									{(cart as { likeCount: number }).likeCount}
+								</span>
+							)}
+							<span className="text-xs px-2 py-0.5 bg-gray-100 text-gray-500 rounded-full">
+								읽기 전용
+							</span>
+						</div>
+					)}
 				</div>
 			</div>
 
@@ -149,14 +192,14 @@ export default function CartDetailPage() {
 										className="w-4 h-4 rounded border-gray-300 accent-gray-800 cursor-pointer"
 									/>
 									<span className="text-sm font-medium text-gray-700">
-										전체 선택
+										{isPublic ? "담을 상품 선택" : "전체 선택"}
 										<span className="ml-1 text-gray-400">
 											({checkedIds.size}/{items.length})
 										</span>
 									</span>
 								</label>
 
-								{checkedIds.size > 0 && (
+								{!isPublic && checkedIds.size > 0 && (
 									<button
 										onClick={handleDeleteChecked}
 										className="text-sm text-red-400 hover:text-red-600 transition-colors">
@@ -204,23 +247,29 @@ export default function CartDetailPage() {
 												</p>
 											</div>
 
-											{/* 수량 컨트롤 */}
-											<div className="flex items-center gap-2">
-												<button
-													onClick={() => handleDecrease(item.id)}
-													disabled={item.quantity <= 1}
-													className="w-8 h-8 flex items-center justify-center rounded-lg border border-[#D9CEBC] bg-white hover:bg-[#F7F3E9] disabled:opacity-30 disabled:cursor-not-allowed transition-colors">
-													<Minus className="w-3.5 h-3.5 text-gray-600" />
-												</button>
-												<span className="w-8 text-center text-sm font-semibold text-gray-800">
-													{item.quantity}
+											{/* 수량 표시 — 공개 장바구니는 텍스트만, 내 장바구니는 +/- 컨트롤 */}
+											{isPublic ? (
+												<span className="text-sm text-gray-500 px-2">
+													×{item.quantity}
 												</span>
-												<button
-													onClick={() => handleIncrease(item.id)}
-													className="w-8 h-8 flex items-center justify-center rounded-lg border border-[#D9CEBC] bg-white hover:bg-[#F7F3E9] transition-colors">
-													<Plus className="w-3.5 h-3.5 text-gray-600" />
-												</button>
-											</div>
+											) : (
+												<div className="flex items-center gap-2">
+													<button
+														onClick={() => handleDecrease(item.id)}
+														disabled={item.quantity <= 1}
+														className="w-8 h-8 flex items-center justify-center rounded-lg border border-[#D9CEBC] bg-white hover:bg-[#F7F3E9] disabled:opacity-30 disabled:cursor-not-allowed transition-colors">
+														<Minus className="w-3.5 h-3.5 text-gray-600" />
+													</button>
+													<span className="w-8 text-center text-sm font-semibold text-gray-800">
+														{item.quantity}
+													</span>
+													<button
+														onClick={() => handleIncrease(item.id)}
+														className="w-8 h-8 flex items-center justify-center rounded-lg border border-[#D9CEBC] bg-white hover:bg-[#F7F3E9] transition-colors">
+														<Plus className="w-3.5 h-3.5 text-gray-600" />
+													</button>
+												</div>
+											)}
 
 											{/* 소계 */}
 											<div className="w-24 text-right">
@@ -229,12 +278,14 @@ export default function CartDetailPage() {
 												</p>
 											</div>
 
-											{/* 삭제 버튼 */}
-											<button
-												onClick={() => handleDelete(item.id)}
-												className="p-2 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors">
-												<Trash2 className="w-4 h-4" />
-											</button>
+											{/* 삭제 버튼 — 공개 장바구니 읽기 전용 시 숨김 */}
+											{!isPublic && (
+												<button
+													onClick={() => handleDelete(item.id)}
+													className="p-2 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors">
+													<Trash2 className="w-4 h-4" />
+												</button>
+											)}
 										</div>
 									);
 								})}
@@ -243,23 +294,25 @@ export default function CartDetailPage() {
 
 						{/* 오른쪽: 주문 요약 패널 + 초대 섹션 (sticky) */}
 						<div className="w-72 shrink-0 sticky top-6 flex flex-col gap-4">
-							{/* 멤버 초대 — 공유 장바구니 전용 */}
-							{cart?.type === "shared" && (
+							{/* 멤버 초대 — 내 공유 장바구니 전용 (공개 장바구니에서는 숨김) */}
+							{!isPublic && cart?.type === "shared" && (
 								<MemberInvite
-									shareLink={`${window.location.origin}/cart?id=${cartId}&type=${cartType}`}
+									shareLink={`${window.location.origin}/cart/detail?id=${cartId}&type=${cartType}`}
 								/>
 							)}
 
 							<div className="bg-white rounded-2xl border border-[#EDE9E0] shadow-sm px-6 py-6 flex flex-col gap-4">
 								<h2 className="text-base font-semibold text-gray-900">
-									주문 요약
+									{isPublic ? "담기 요약" : "주문 요약"}
 								</h2>
 
 								{/* 체크된 상품별 소계 목록 */}
 								<div className="flex flex-col gap-2">
 									{checkedItems.length === 0 ? (
 										<p className="text-sm text-gray-400 text-center py-2">
-											선택된 상품이 없습니다
+											{isPublic
+												? "담을 상품을 선택해 주세요"
+												: "선택된 상품이 없습니다"}
 										</p>
 									) : (
 										checkedItems.map((item) => (
@@ -292,11 +345,35 @@ export default function CartDetailPage() {
 									</div>
 								</div>
 
-								<button
-									disabled={checkedItems.length === 0}
-									className="w-full py-3.5 bg-[#F7F3E9] hover:bg-[#F3EEE0] disabled:opacity-40 disabled:cursor-not-allowed text-black font-semibold rounded-xl transition-colors text-sm tracking-wide shadow-sm">
-									주문하기 ({checkedItems.length})
-								</button>
+								{isPublic ? (
+									/* 공개 장바구니: 선택 상품 담기 + 모두 담기 버튼 */
+									<div className="flex flex-col gap-2">
+										<button
+											disabled={checkedItems.length === 0}
+											onClick={openSelectCartModal}
+											className="w-full py-3.5 bg-[#F7F3E9] hover:bg-[#F3EEE0] disabled:opacity-40 disabled:cursor-not-allowed text-black font-semibold rounded-xl transition-colors text-sm tracking-wide shadow-sm flex items-center justify-center gap-2">
+											<ShoppingCart className="w-4 h-4" />
+											선택 상품 담기 ({checkedItems.length})
+										</button>
+										<button
+											onClick={() => {
+												// 모두 선택 후 모달 열기
+												setCheckedIds(new Set(items.map((i) => i.id)));
+												openSelectCartModal();
+											}}
+											className="w-full py-3.5 border border-[#D9CEBC] hover:bg-[#FDFBF6] text-gray-700 font-semibold rounded-xl transition-colors text-sm tracking-wide flex items-center justify-center gap-2">
+											<ShoppingCart className="w-4 h-4" />
+											모두 담기 ({items.length})
+										</button>
+									</div>
+								) : (
+									/* 내 장바구니: 주문하기 버튼 */
+									<button
+										disabled={checkedItems.length === 0}
+										className="w-full py-3.5 bg-[#F7F3E9] hover:bg-[#F3EEE0] disabled:opacity-40 disabled:cursor-not-allowed text-black font-semibold rounded-xl transition-colors text-sm tracking-wide shadow-sm">
+										주문하기 ({checkedItems.length})
+									</button>
+								)}
 							</div>
 						</div>
 					</div>

--- a/src/pages/cart/CartListPage.tsx
+++ b/src/pages/cart/CartListPage.tsx
@@ -1,11 +1,11 @@
 import { useState } from "react";
-import { ShoppingCart, Users, User, ChevronRight } from "lucide-react";
+import { ShoppingCart, Users, User } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { publicCarts } from "../../mock/cartData";
 import type { PublicCart, CartCategory } from "../../mock/cartData";
 
 // ─────────────────────────────────────────
-// 카테고리 탭 정의 (ProductSection과 동일 순서)
+// 카테고리 탭 정의
 // ─────────────────────────────────────────
 const cartCategories: { id: CartCategory; label: string }[] = [
 	{ id: "living", label: "생활용품" },
@@ -14,8 +14,10 @@ const cartCategories: { id: CartCategory; label: string }[] = [
 	{ id: "camping", label: "캠핑용품" },
 ];
 
+const PAGE_SIZE = 24; // 4열 × 6행
+
 // ─────────────────────────────────────────
-// 유틸: 대표 썸네일 반환
+// 유틸
 // ─────────────────────────────────────────
 function getRepresentativeThumbnail(items: PublicCart["items"]): string {
 	return items.length > 0
@@ -23,15 +25,12 @@ function getRepresentativeThumbnail(items: PublicCart["items"]): string {
 		: "https://images.unsplash.com/photo-1506617564039-2f3b650b7010?w=400&q=80";
 }
 
-// ─────────────────────────────────────────
-// 유틸: 장바구니 총 금액 계산
-// ─────────────────────────────────────────
 function calcTotalPrice(items: PublicCart["items"]): number {
 	return items.reduce((sum, item) => sum + item.price * item.quantity, 0);
 }
 
 // ─────────────────────────────────────────
-// CartCard 컴포넌트
+// CartCard — 클릭 시 상세 페이지로 이동
 // ─────────────────────────────────────────
 function CartCard({ cart }: { cart: PublicCart }) {
 	const navigate = useNavigate();
@@ -40,12 +39,13 @@ function CartCard({ cart }: { cart: PublicCart }) {
 	const thumbnail = getRepresentativeThumbnail(cart.items);
 
 	const handleClick = () => {
+		// source=public 파라미터로 공개 장바구니임을 CartDetailPage에 알림
 		navigate(`/cart/detail?id=${cart.id}&type=${cart.type}&source=public`);
 	};
 
 	return (
 		<div className="group flex flex-col cursor-pointer" onClick={handleClick}>
-			{/* 대표 상품 이미지 */}
+			{/* 대표 이미지 */}
 			<div
 				className="relative w-full rounded-xl overflow-hidden mb-3"
 				style={{ aspectRatio: "1 / 1" }}>
@@ -56,9 +56,9 @@ function CartCard({ cart }: { cart: PublicCart }) {
 				/>
 			</div>
 
-			{/* 장바구니 정보 */}
+			{/* 카드 정보 */}
 			<div className="flex flex-col gap-1">
-				{/* 장바구니 이름 + 개인/공유 뱃지 (이름 오른쪽) */}
+				{/* 장바구니 이름 + 개인/공유 뱃지 */}
 				<div className="flex items-center gap-1.5">
 					<ShoppingCart className="w-3.5 h-3.5 text-[#C8A97A] shrink-0" />
 					<p className="text-sm font-semibold text-gray-900 leading-snug line-clamp-1 flex-1">
@@ -77,7 +77,7 @@ function CartCard({ cart }: { cart: PublicCart }) {
 					</span>
 				</div>
 
-				{/* 소유자 닉네임 + 담긴 상품 개수 */}
+				{/* 소유자 · 상품 개수 */}
 				<p className="text-xs text-gray-400">
 					<span className="font-medium text-gray-500">{cart.ownerName}</span>
 					{" · "}담긴 상품{" "}
@@ -96,32 +96,39 @@ function CartCard({ cart }: { cart: PublicCart }) {
 }
 
 // ─────────────────────────────────────────
-// CartSection (메인 페이지 노출용)
+// CartListPage
 // ─────────────────────────────────────────
-export default function CartSection() {
-	const navigate = useNavigate();
+export default function CartListPage() {
 	const [activeCategory, setActiveCategory] = useState<CartCategory>(
 		cartCategories[0].id
 	);
 
-	// 선택된 카테고리로 필터링 후 인기순(likeCount 내림차순) 정렬, 최대 8개
+	// 선택 카테고리 필터링 → 인기순 정렬 → 최대 PAGE_SIZE(24)개
 	const filteredCarts = publicCarts
 		.filter((c) => c.category === activeCategory)
 		.sort((a, b) => b.likeCount - a.likeCount)
-		.slice(0, 8);
+		.slice(0, PAGE_SIZE);
 
 	const currentCategory = cartCategories.find((c) => c.id === activeCategory)!;
 
 	return (
-		<section className="w-full bg-white py-16">
-			<div className="max-w-7xl mx-auto px-6">
-				{/* 섹션 타이틀 */}
-				<h2 className="text-2xl font-bold text-gray-900 mb-5">
-					가장 인기있는 장바구니
-				</h2>
+		<div className="min-h-screen bg-white">
+			{/* 페이지 헤더 영역 */}
+			<div className="bg-white">
+				<div className="max-w-7xl mx-auto px-6 py-10">
+					<h1 className="text-3xl font-bold text-gray-900">
+						{currentCategory.label} 장바구니
+					</h1>
+					<p className="mt-2 text-sm text-gray-500">
+						다른 사람들이 공개한 인기 장바구니를 확인해 보세요
+					</p>
+				</div>
+			</div>
 
+			{/* 본문 */}
+			<div className="max-w-7xl mx-auto px-6 py-10">
 				{/* 카테고리 탭 */}
-				<div className="flex border-b border-gray-200 mb-6">
+				<div className="flex border-b border-gray-200 mb-8">
 					{cartCategories.map((cat) => (
 						<button
 							key={cat.id}
@@ -136,34 +143,30 @@ export default function CartSection() {
 					))}
 				</div>
 
-				{/* 장바구니 그리드: 4열 */}
+				{/* 결과 카운트 */}
+				<p className="text-sm text-gray-400 mb-6">
+					<span className="font-medium text-gray-700">
+						{filteredCarts.length}개
+					</span>
+					의 장바구니
+				</p>
+
+				{/* 그리드: 4열 × 6행 */}
 				{filteredCarts.length > 0 ? (
-					<div className="grid grid-cols-4 gap-x-6 gap-y-16">
+					<div className="grid grid-cols-4 gap-x-6 gap-y-14">
 						{filteredCarts.map((cart) => (
 							<CartCard key={cart.id} cart={cart} />
 						))}
 					</div>
 				) : (
-					<div className="flex flex-col items-center justify-center py-24 gap-3 text-gray-400">
-						<ShoppingCart className="w-12 h-12 opacity-30" />
-						<p className="text-sm">
-							{currentCategory.label} 카테고리의 인기 장바구니가 없습니다.
+					<div className="flex flex-col items-center justify-center py-32 gap-4 text-gray-400">
+						<ShoppingCart className="w-14 h-14 opacity-20" />
+						<p className="text-base">
+							{currentCategory.label} 카테고리의 공개 장바구니가 없습니다.
 						</p>
 					</div>
 				)}
-
-				{/* 전체보기 버튼 */}
-				{filteredCarts.length > 0 && (
-					<div className="flex justify-center mt-10">
-						<button
-							onClick={() => navigate("/cart")}
-							className="px-16 py-4 border border-gray-200 rounded-2xl flex items-center justify-center gap-1.5 text-gray-500 font-medium hover:bg-[#F6F0E4] hover:border-[#D4B896] transition-all">
-							<span>{currentCategory.label} 장바구니 전체보기</span>
-							<ChevronRight className="w-4 h-4" />
-						</button>
-					</div>
-				)}
 			</div>
-		</section>
+		</div>
 	);
 }

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -1,11 +1,12 @@
 import MainCarousel from "../../components/layout/MainCarousel.tsx";
+import CartSection from "../../components/cart/CartSection.tsx";
 import ProductSection from "../../components/products/ProductSection.tsx";
 
 export default function MainPage() {
 	return (
 		<main className="flex-1 bg-white">
 			<MainCarousel />
-			<ProductSection title="세일 중인 상품" />
+			<CartSection />
 			<ProductSection title="가장 인기있는 상품" />
 		</main>
 	);

--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -3,18 +3,24 @@ import GlobalLayout from "../components/layout/GlobalLayout";
 import MainPage from "../pages/main/MainPage.tsx";
 import LoginPage from "../pages/login/LoginPage.tsx";
 import ProductDetailPage from "../pages/products/ProductDetailPage.tsx";
+import CartListPage from "../pages/cart/CartListPage.tsx";
 import CartDetailPage from "../pages/cart/CartDetailPage.tsx";
+import ScrollToTop from "../components/layout/ScrollToTop.tsx";
 
 export default function AppRouter() {
 	return (
-		<Routes>
-			<Route path="/login" element={<LoginPage />} />
+		<>
+			<ScrollToTop />
+			<Routes>
+				<Route path="/login" element={<LoginPage />} />
 
-			<Route element={<GlobalLayout />}>
-				<Route path="/" element={<MainPage />} />
-				<Route path="/product/:id" element={<ProductDetailPage />} />
-				<Route path="/cart" element={<CartDetailPage />} />
-			</Route>
-		</Routes>
+				<Route element={<GlobalLayout />}>
+					<Route path="/" element={<MainPage />} />
+					<Route path="/product/:id" element={<ProductDetailPage />} />
+					<Route path="/cart" element={<CartListPage />} />
+					<Route path="/cart/detail" element={<CartDetailPage />} />
+				</Route>
+			</Routes>
+		</>
 	);
 }


### PR DESCRIPTION
## 🛠️ 설명 (Description)

- `MainPage.tsx`에 기존 세일 중인 상품에서 가장 인기있는 장바구니로 수정
- 다른 사람들의 장바구니를 볼 수 있는 장바구니 목록 페이지 구현


## 📝 변경 사항 요약 (Summary)

- `index.html` 및 `Footer.tsx`의 서비스명을 'MisePrep'으로 변경
- `MainHeader.tsx`의 네비게이션 메뉴를 장바구니, 베스트, 생활용품, 식재료, 사무용품, 캠핑용품으로 업데이트
- `MainPage.tsx`에 타인의 공개 장바구니를 보여주는 `CartSection.tsx` 신규 추가
- `ScrollToTop` 컴포넌트 추가 및 `AppRouter` 적용으로 페이지 이동 시 스크롤 최상단
- 장바구니 목록 페이지 `CartDetailPage.tsx` 구현
- `CartListPage` 신규 구현 및 카테고리별(생활, 사무, 캠핑 등) 공개 장바구니 데이터 확장


## 🔗 관련 이슈 (Related Issues)

- Closes #None
- Related #21 

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

## ➕ 추가 정보 (Additional Information)
